### PR TITLE
distutils is deprecated from Python 3.10 with removal planned for Python 3.12

### DIFF
--- a/pycutest/install_scripts.py
+++ b/pycutest/install_scripts.py
@@ -26,10 +26,8 @@ setupScript="""#!/usr/bin/env python
 # Ensure compatibility with Python 2
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from distutils.core import setup, Extension
 import os
 import numpy as np
-from subprocess import call
 from glob import glob
 
 #
@@ -42,31 +40,46 @@ from glob import glob
 # End of OS specific
 #
 
-# Module
-module1 = Extension(
-      str('_pycutestitf'),
-      [str('cutestitf.c')],
-      include_dirs=include_dirs,
-      define_macros=define_macros,
-      extra_objects=objFileList,
-      libraries=libraries,
-      library_dirs=library_dirs,
-      extra_link_args=extra_link_args
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+    config = Configuration(None, parent_package, top_path)
+    config.set_options(
+        ignore_setup_xxx_py=True,
+        assume_default_configuration=True,
+        delegate_options_to_subpackages=True,
+        quiet=True,
     )
 
+    # Module
+    config.add_extension(
+        str('_pycutestitf'),
+        [str('cutestitf.c')],
+        include_dirs=include_dirs,
+        define_macros=define_macros,
+        extra_objects=objFileList,
+        libraries=libraries,
+        library_dirs=library_dirs,
+        extra_link_args=extra_link_args,
+    )
+
+    return config
+
 # Settings
-setup(name='PyCUTEst automatic test function interface builder',
-    version='1.0',
-    description='Builds a CUTEst test function interface for Python.',
-    long_description='Builds a CUTEst test function interface for Python.',
-    author='Arpad Buermen, Jaroslav Fowkes, Lindon Roberts',
-    author_email='arpadb@fides.fe.uni-lj.si, fowkes@maths.ox.ac.uk, robertsl@maths.ox.ac.uk',
-    url='',
-    platforms='Linux',
-    license='GNU GPL',
-    packages=[],
-    ext_modules=[module1]
-)
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(
+        name='PyCUTEst automatic test function interface builder',
+        version='1.0',
+        description='Builds a CUTEst test function interface for Python.',
+        long_description='Builds a CUTEst test function interface for Python.',
+        author='Arpad Buermen, Jaroslav Fowkes, Lindon Roberts',
+        author_email='arpadb@fides.fe.uni-lj.si, fowkes@maths.ox.ac.uk, robertsl@maths.ox.ac.uk',
+        url='',
+        platforms='Linux',
+        license='GNU GPL',
+        packages=[],
+        configuration=configuration,
+    )
 """
 
 #
@@ -74,9 +87,9 @@ setup(name='PyCUTEst automatic test function interface builder',
 #
 setupScriptLinux="""
 define_macros=[('LINUX', None)]
-include_dirs=[os.path.join(np.get_include(), 'numpy'),os.environ['CUTEST']+'/include/']
+include_dirs=[os.path.join(np.get_include(), 'numpy'), os.path.join(os.environ['CUTEST'], 'include')]
 objFileList=glob('*.o')
-objFileList.append(os.environ['CUTEST']+'/objects/'+os.environ['MYARCH']+'/double/libcutest.a')
+objFileList.append(os.path.join(os.environ['CUTEST'], 'objects', os.environ['MYARCH'], 'double', 'libcutest.a'))
 libraries=['gfortran']
 library_dirs=[]
 extra_link_args=[]

--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -160,8 +160,8 @@ class CUTEstProblem(object):
             self.vartype = self.all_to_free(self.vartype)
             # Not updating self.nnzh and self.nnzj, because even isphess doesn't give right results
         else:  # Doesn't matter whether they are actually fixed or free, they all look free to us
-            self.idx_eq = np.array([], dtype=np.int)
-            self.idx_free = np.arange(self.n, dtype=np.int)
+            self.idx_eq = np.array([], dtype=int)
+            self.idx_free = np.arange(self.n, dtype=int)
             self.n_fixed = 0
             self.n_free = self.n_full
             self.n = self.n_full

--- a/pycutest/tests/test_basic_functionality.py
+++ b/pycutest/tests/test_basic_functionality.py
@@ -190,8 +190,8 @@ class TestALLINITC_with_fixed(unittest.TestCase):
         self.assertTrue(array_compare(p.v0, np.array([0.0])), msg="Wrong v0")
         self.assertTrue(array_compare(p.cl, np.array([0.0])), msg="Wrong cl") 
         self.assertTrue(array_compare(p.cu, np.array([0.0])), msg="Wrong cu")
-        self.assertEqual(p.is_eq_cons, np.array([True], dtype=np.bool), msg="Wrong is_eq_cons")
-        self.assertEqual(p.is_linear_cons, np.array([False], dtype=np.bool), msg="Wrong is_linear_cons")
+        self.assertEqual(p.is_eq_cons, np.array([True], dtype=bool), msg="Wrong is_eq_cons")
+        self.assertEqual(p.is_linear_cons, np.array([False], dtype=bool), msg="Wrong is_linear_cons")
 
         # If we need to multiply against another vector, use these
         ps = [np.zeros((4,)), 0.3 * np.ones((4,)), -0.5*np.arange(4)]
@@ -328,8 +328,8 @@ class TestALLINITC_with_free(unittest.TestCase):
         self.assertTrue(array_compare(p.v0, np.array([0.0])), msg="Wrong v0")
         self.assertTrue(array_compare(p.cl, np.array([0.0])), msg="Wrong cl") 
         self.assertTrue(array_compare(p.cu, np.array([0.0])), msg="Wrong cu")
-        self.assertEqual(p.is_eq_cons, np.array([True], dtype=np.bool), msg="Wrong is_eq_cons")
-        self.assertEqual(p.is_linear_cons, np.array([False], dtype=np.bool), msg="Wrong is_linear_cons")
+        self.assertEqual(p.is_eq_cons, np.array([True], dtype=bool), msg="Wrong is_eq_cons")
+        self.assertEqual(p.is_linear_cons, np.array([False], dtype=bool), msg="Wrong is_linear_cons")
 
         # If we need to multiply against another vector, use these
         ps = [np.zeros((3,)), 0.3 * np.ones((3,)), -0.5*np.arange(3)]


### PR DESCRIPTION
Hi!

I am using PyCUTEst with Python 3.10, for which `distutils` is deprecated. This PR should fix the issue.

I hope this can be useful.

Thank you very much,
Tom.