### PR TITLE
Remove deprecated calls

### DIFF
--- a/pycutest/build_interface.py
+++ b/pycutest/build_interface.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os, shutil, sys
 import subprocess
 from glob import glob
-import warnings
 
 from .system_paths import get_cache_path, get_sifdecoder_path
 from .c_interface import itf_c_source
@@ -300,7 +299,7 @@ def compile_and_install_interface(problemName, destination=None, sifParams=None,
         raise RuntimeError("Failed to build the Python interface module")
 
     # Call 'python setup.py install --install-lib .'
-    if subprocess.call([sys.executable, 'setup.py']+quietopt+['install', '--install-lib', '.'])!=0:
+    if subprocess.call([sys.executable, '-m', 'pip']+quietopt+['install', '.'])!=0:
         raise RuntimeError("Failed to install the Python interface module")
 
     # Create __init__.py

--- a/pycutest/build_interface.py
+++ b/pycutest/build_interface.py
@@ -299,7 +299,7 @@ def compile_and_install_interface(problemName, destination=None, sifParams=None,
         raise RuntimeError("Failed to build the Python interface module")
 
     # Call 'python setup.py install --install-lib .'
-    if subprocess.call([sys.executable, '-m', 'pip']+quietopt+['install', '.'])!=0:
+    if subprocess.call([sys.executable, 'setup.py']+quietopt+['build_ext', '--inplace'])!=0:
         raise RuntimeError("Failed to install the Python interface module")
 
     # Create __init__.py

--- a/pycutest/install_scripts.py
+++ b/pycutest/install_scripts.py
@@ -26,11 +26,11 @@ setupScript="""#!/usr/bin/env python
 # Ensure compatibility with Python 2
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from distutils.core import setup, Extension
 import os
+
 import numpy as np
-from subprocess import call
 from glob import glob
+from setuptools import setup, Extension, find_packages
 
 #
 # OS specific
@@ -43,19 +43,20 @@ from glob import glob
 #
 
 # Module
-module1 = Extension(
-      str('_pycutestitf'),
-      [str('cutestitf.c')],
-      include_dirs=include_dirs,
-      define_macros=define_macros,
-      extra_objects=objFileList,
-      libraries=libraries,
-      library_dirs=library_dirs,
-      extra_link_args=extra_link_args
-    )
+module = Extension(
+    str('_pycutestitf'),
+    sources=[str('cutestitf.c')],
+    include_dirs=include_dirs,
+    define_macros=define_macros,
+    extra_objects=objFileList,
+    libraries=libraries,
+    library_dirs=library_dirs,
+    extra_link_args=extra_link_args,
+)
 
 # Settings
-setup(name='PyCUTEst automatic test function interface builder',
+setup(
+    name='PyCUTEst automatic test function interface builder',
     version='1.0',
     description='Builds a CUTEst test function interface for Python.',
     long_description='Builds a CUTEst test function interface for Python.',
@@ -64,8 +65,8 @@ setup(name='PyCUTEst automatic test function interface builder',
     url='',
     platforms='Linux',
     license='GNU GPL',
-    packages=[],
-    ext_modules=[module1]
+    packages=find_packages(),
+    ext_modules=[module],
 )
 """
 

--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -160,8 +160,8 @@ class CUTEstProblem(object):
             self.vartype = self.all_to_free(self.vartype)
             # Not updating self.nnzh and self.nnzj, because even isphess doesn't give right results
         else:  # Doesn't matter whether they are actually fixed or free, they all look free to us
-            self.idx_eq = np.array([], dtype=np.int)
-            self.idx_free = np.arange(self.n, dtype=np.int)
+            self.idx_eq = np.array([], dtype=int)
+            self.idx_free = np.arange(self.n, dtype=int)
             self.n_fixed = 0
             self.n_free = self.n_full
             self.n = self.n_full
@@ -200,12 +200,12 @@ class CUTEstProblem(object):
             return pad_vector(x, self.idx_free, self.idx_eq, np.zeros((self.n_full,)) if use_zeros else self.bl_full)
         else:
             return x
-    
+
     def check_input_x(self, x):
         """
         Check x has correct dimensions
-        
-        :param x: input vector 
+
+        :param x: input vector
         :return: raises RuntimeError if x has wrong dimension
         """
         if x.shape != (self.n,):

--- a/pycutest/tests/test_basic_functionality.py
+++ b/pycutest/tests/test_basic_functionality.py
@@ -188,10 +188,10 @@ class TestALLINITC_with_fixed(unittest.TestCase):
         self.assertTrue(array_compare(p.bu, np.array([1e20, 1e20, 1.0, 2.0])), msg="Wrong upper bounds")
         self.assertEqual(p.nnzj, 2, msg="Wrong nnzj")
         self.assertTrue(array_compare(p.v0, np.array([0.0])), msg="Wrong v0")
-        self.assertTrue(array_compare(p.cl, np.array([0.0])), msg="Wrong cl") 
+        self.assertTrue(array_compare(p.cl, np.array([0.0])), msg="Wrong cl")
         self.assertTrue(array_compare(p.cu, np.array([0.0])), msg="Wrong cu")
-        self.assertEqual(p.is_eq_cons, np.array([True], dtype=np.bool), msg="Wrong is_eq_cons")
-        self.assertEqual(p.is_linear_cons, np.array([False], dtype=np.bool), msg="Wrong is_linear_cons")
+        self.assertEqual(p.is_eq_cons, np.array([True], dtype=bool), msg="Wrong is_eq_cons")
+        self.assertEqual(p.is_linear_cons, np.array([False], dtype=bool), msg="Wrong is_linear_cons")
 
         # If we need to multiply against another vector, use these
         ps = [np.zeros((4,)), 0.3 * np.ones((4,)), -0.5*np.arange(4)]
@@ -326,10 +326,10 @@ class TestALLINITC_with_free(unittest.TestCase):
         self.assertTrue(array_compare(p.bu, np.array([1e20, 1e20, 1.0])), msg="Wrong upper bounds")
         self.assertEqual(p.nnzj, 2, msg="Wrong nnzj")
         self.assertTrue(array_compare(p.v0, np.array([0.0])), msg="Wrong v0")
-        self.assertTrue(array_compare(p.cl, np.array([0.0])), msg="Wrong cl") 
+        self.assertTrue(array_compare(p.cl, np.array([0.0])), msg="Wrong cl")
         self.assertTrue(array_compare(p.cu, np.array([0.0])), msg="Wrong cu")
-        self.assertEqual(p.is_eq_cons, np.array([True], dtype=np.bool), msg="Wrong is_eq_cons")
-        self.assertEqual(p.is_linear_cons, np.array([False], dtype=np.bool), msg="Wrong is_linear_cons")
+        self.assertEqual(p.is_eq_cons, np.array([True], dtype=bool), msg="Wrong is_eq_cons")
+        self.assertEqual(p.is_linear_cons, np.array([False], dtype=bool), msg="Wrong is_linear_cons")
 
         # If we need to multiply against another vector, use these
         ps = [np.zeros((3,)), 0.3 * np.ones((3,)), -0.5*np.arange(3)]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist =
+    py36
+    py37
+    py38
+    py39
+    py310
+skipsdist = True
+
+[testenv]
+deps =
+    numpy
+    scipy
+passenv = *
+setenv =
+    PYCUTEST_CACHE = {envtmpdir}
+commands =
+    {envpython} -m unittest


### PR DESCRIPTION
Hi @jfowkes,

Here are the modifications we discussed. They include

1. removing the deprecated calls to `np.int` and `np.bool`,
2. removing importations of unused libraries,
3. replacing the call to the deprecated `python setup.py install` by `python setup.py build_ext --inplace`, and
4. using `setuptools` instead of `distutils` to compile the external sources.

Note that the original call `python setup.py install` was slightly unnecessary, as only the external libraries was used by `pycutest`. Also, I created a configuration file for using [tox](https://tox.wiki/en/latest/) to test the software. Assuming that you have installed on your machine `python3.6`, `python3.7`, `python3.8`, `python3.9`, and `python3.10`, and that CUTEst is correctly set up, you can test `pycutest` against all versions of Python by install `tox` via PyPI and running `python -m tox`.

I hope this time things will work on macOS.
Tom.