### PR TITLE
Automatically upload to pypi on release

### DIFF
--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -1,0 +1,25 @@
+name: Package and upload to PyPI
+
+# Publish when a (published) GitHub Release is created
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build_publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - name: Build universal wheel
+        run: python setup.py bdist_wheel
+
+      - uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Automatically create package sources and universal wheel and upload them to PyPI every time a new release is created on GitHub 