### PR TITLE
Add pull request/issue templates and support guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behaviour, including a code snippet showing how the error occurred
+and any relevant Python output messages.
+
+**Information about your installation:**
+ - Operating System
+ - Python Version / Distribution
+ - PyCUTEst Version

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: Ask a question
+title: ''
+labels: question
+assignees: ''
+
+---
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+
+**Describe the change(s)**
+A clear and concise description of the change(s). If you are fixing an issue, please reference the issue number.
+
+**Have you updated the documentation?**
+We use [Sphinx](https://www.sphinx-doc.org/en/master/) to create our documentation which is located in the `docs` subdirectory. You will need to install both the `sphinx` and `sphinx-rtd-theme` packages.
+
+**Have you included relevant unit tests?**
+We use [nose](https://nose.readthedocs.io/en/latest/) to run our unit tests which are located in `pycutest/tests`. We also provide a `tox.ini` for local testing using [tox](https://tox.wiki/en/latest/). 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Contributions to PyCUTEst are always welcome - thanks for your interest in getti
 ### Reporting Bugs / Feature Suggestions
 
 If you find a bug in PyCUTEst, or have a suggestion about how PyCUTEst can be improved, please
-[create a Github issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue).
-It would be helpful if you first check the [existing list of open issues](https://github.com/jfowkes/pycutest/issues)
+[create a GitHub issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue).
+It would be helpful if you could first check the [existing list of open issues](https://github.com/jfowkes/pycutest/issues)
 to see if someone else has reported the same thing - in this case it would be better to comment on the existing issue
 rather than creating a new one.
 
@@ -15,7 +15,7 @@ rather than creating a new one.
 We are happy to accept code contributions from the PyCUTEst community.
 If you have made a change (bugfix, new feature, documentation improvement, etc), then please
 [submit a pull request](https://github.com/jfowkes/pycutest/pulls).
-Github has [more information on pull requests](https://docs.github.com/en/pull-requests).
+GitHub has [more information on pull requests](https://docs.github.com/en/pull-requests).
 
 ### Code of Conduct
 We expect everyone in the PyCUTEst community to show respect to each other and behave appropriately at all times.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,30 +10,12 @@ It would be helpful if you first check the [existing list of open issues](https:
 to see if someone else has reported the same thing - in this case it would be better to comment on the existing issue
 rather than creating a new one.
 
-When reporting a bug, it would be helpful if you could include:
-
-* An informative title and clear description
-* A code snippet showing how the error occurred
-* Any relevant Python output messages
-* Information about your installation (e.g. operating system, Python version/distribution, PyCUTEst version)
-
 ### Submitting code changes
 
 We are happy to accept code contributions from the PyCUTEst community.
 If you have made a change (bugfix, new feature, documentation improvement, etc), then please
 [submit a pull request](https://github.com/jfowkes/pycutest/pulls).
 Github has [more information on pull requests](https://docs.github.com/en/pull-requests).
-Please ensure that:
-
-* Your description clearly explains your changes
-* You have updated the documentation in `docs`.
-We use [Sphinx](https://www.sphinx-doc.org/en/master/) to create our documentation.
-You will need to install both the Sphinx and sphinx-rtd-theme packages.
-* You have included relevant unit tests in `pycutest/tests`.
-We use [nose](https://nose.readthedocs.io/en/latest/) to run our unit tests
-but we do also provide a `tox.ini` for local testing using [tox](https://tox.wiki/en/latest/).
-
-If you are fixing an issue, please reference the issue number in the pull request.
 
 ### Code of Conduct
 We expect everyone in the PyCUTEst community to show respect to each other and behave appropriately at all times.

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,10 @@ Note that you can uninstall PyCUTEst as follows:
 
     $ pip uninstall pycutest
 
+Support
+-------
+Please ask any questions or report problems using GitHub's issue tracker.
+
 Bugs
 ----
 Please report any bugs using GitHub's issue tracker.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -10,8 +10,8 @@ Reporting Bugs / Feature Suggestions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you find a bug in PyCUTEst, or have a suggestion about how PyCUTEst can be improved, please
-`create a Github issue <https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue>`_.
-It would be helpful if you first check the `existing list of open issues <https://github.com/jfowkes/pycutest/issues>`_
+`create a GitHub issue <https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue>`_.
+It would be helpful if you could first check the `existing list of open issues <https://github.com/jfowkes/pycutest/issues>`_
 to see if someone else has reported the same thing - in this case it would be better to comment on the existing issue
 rather than creating a new one.
 
@@ -21,7 +21,7 @@ Submitting code changes
 We are happy to accept code contributions from the PyCUTEst community.
 If you have made a change (bugfix, new feature, documentation improvement, etc), then please
 `submit a pull request <https://github.com/jfowkes/pycutest/pulls>`_.
-Github has `more information on pull requests <https://docs.github.com/en/pull-requests>`_.
+GitHub has `more information on pull requests <https://docs.github.com/en/pull-requests>`_.
 
 Code of Conduct
 ^^^^^^^^^^^^^^^

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -15,13 +15,6 @@ It would be helpful if you first check the `existing list of open issues <https:
 to see if someone else has reported the same thing - in this case it would be better to comment on the existing issue
 rather than creating a new one.
 
-When reporting a bug, it would be helpful if you could include:
-
-* An informative title and clear description
-* A code snippet showing how the error occurred
-* Any relevant Python output messages
-* Information about your installation (e.g. operating system, Python version/distribution, PyCUTEst version)
-
 Submitting code changes
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -29,17 +22,6 @@ We are happy to accept code contributions from the PyCUTEst community.
 If you have made a change (bugfix, new feature, documentation improvement, etc), then please
 `submit a pull request <https://github.com/jfowkes/pycutest/pulls>`_.
 Github has `more information on pull requests <https://docs.github.com/en/pull-requests>`_.
-Please ensure that:
-
-* Your description clearly explains your changes
-* You have updated the documentation in :code:`docs`.
-  We use `Sphinx <https://www.sphinx-doc.org/en/master/>`_ to create our documentation.
-  You will need to install both the Sphinx and sphinx-rtd-theme packages.
-* You have included relevant unit tests in :code:`pycutest/tests`.
-  We use `nose <https://nose.readthedocs.io/en/latest/>`_ to run our unit tests
-  but we do also provide a :code:`tox.ini` for local testing using `tox <https://tox.wiki/en/latest/>`_.
-
-If you are fixing an issue, please reference the issue number in the pull request.
 
 Code of Conduct
 ^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ Our aim is for PyCUTEst to make it easier for both optimization users and softwa
    building
    interface
    example
+   support
    contributing
    history
 

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,0 +1,9 @@
+Support
+=======
+
+Support for PyCUTEst
+--------------------
+
+If you require any support with using PyCUTEst, please feel free to either email the PyCUTEst team
+(`Jari <mailto:jaroslav.fowkes@stfc.ac.uk>`_ and `Lindon <mailto:lindon.roberts@sydney.edu.au>`_)
+or `open a GitHub issue <https://github.com/jfowkes/pycutest/issues>`_ with your query.


### PR DESCRIPTION
As suggested in our JOSS review:
https://github.com/openjournals/joss-reviews/issues/4377
we should make the following two changes:
- [x] use GitHub templates for pull request/issues, which will allow removing the "include this information in your PR/issue" in `CONTRIBUTING.md`.
- [x] add "clear" guidelines for anyone "seeking support" (though it's not explicit, people seeking support do have a mechanism to obtain support)