### PR TITLE
C interface modernisation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Requirements
 ------------
 PyCUTEst requires the following software to be installed:
 
-* Python 2.7 or Python 3 (http://www.python.org/)
+* Python 3 (http://www.python.org/)
 * CUTEst (see below)
 
 **Please Note:** Currently PyCUTEst only supports Mac and Linux. For Windows 10 (or later), PyCUTEst can be used through the `Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/>`_, following the Linux installation instructions.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,7 +5,7 @@ Requirements
 ------------
 PyCUTEst requires the following software to be installed:
 
-* Python 2.7 or Python 3 (http://www.python.org/)
+* Python 3 (http://www.python.org/)
 * CUTEst (see below)
 
 **Please Note:** Currently PyCUTEst only supports Mac and Linux. For Windows 10 (or later), PyCUTEst can be used through the `Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/>`_, following the Linux installation instructions.

--- a/pycutest/build_interface.py
+++ b/pycutest/build_interface.py
@@ -5,6 +5,7 @@ Main routines for building and managing interfaces
 """
 import os, shutil, sys
 import subprocess
+import importlib
 from glob import glob
 
 from .system_paths import get_cache_path, get_sifdecoder_path
@@ -341,11 +342,11 @@ def import_problem(problemName, destination=None, sifParams=None, sifOptions=Non
         problemDir = destination
     # Import the module CACHE_SUBFOLDER.problemDir, and return a wrapper
     try:
-        return CUTEstProblem(__import__('%s.%s' % (CACHE_SUBFOLDER, problemDir), globals(), locals(), [str(problemDir)]),
+        return CUTEstProblem(importlib.import_module('%s.%s' % (CACHE_SUBFOLDER, problemDir)),
                              drop_fixed_variables=drop_fixed_variables)
     except ImportError as error:
         try: # check if cache folder is on python path
-            __import__(CACHE_SUBFOLDER)
+            importlib.import_module(CACHE_SUBFOLDER)
         except ImportError:
             raise ImportError('cannot import PYCUTEST_CACHE folder, have you added it to your python path?')
         else: # else raise original error

--- a/pycutest/build_interface.py
+++ b/pycutest/build_interface.py
@@ -3,10 +3,6 @@
 """
 Main routines for building and managing interfaces
 """
-
-# Ensure compatibility with Python 2
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os, shutil, sys
 import subprocess
 from glob import glob

--- a/pycutest/c_interface.py
+++ b/pycutest/c_interface.py
@@ -38,9 +38,9 @@ itf_c_source = r"""
 
 #define NPY_NO_DEPRECATED_API NPY_1_8_API_VERSION
 
-#include "Python.h"
-#include "cutest.h"
-#include "arrayobject.h"
+#include <Python.h>
+#include <cutest.h>
+#include <numpy/arrayobject.h>
 #include <math.h>
 #include <stdio.h>
 

--- a/pycutest/install_scripts.py
+++ b/pycutest/install_scripts.py
@@ -2,9 +2,6 @@
 Installation scripts for individual problems
 """
 
-# Ensure compatibility with Python 2
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 
 from .system_paths import get_cutest_path
@@ -16,15 +13,12 @@ __all__ = ['get_setup_script']
 #
 setupScript="""#!/usr/bin/env python
 # (C)2011 Arpad Buermen
-# (C)2018 Jaroslav Fowkes, Lindon Roberts
+# (C)2022 Jaroslav Fowkes, Lindon Roberts
 # Licensed under GNU GPL V3
 
 #
 # Do not edit. This is a computer-generated file.
 #
-
-# Ensure compatibility with Python 2
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 
@@ -57,7 +51,7 @@ module = Extension(
 # Settings
 setup(
     name='PyCUTEst automatic test function interface builder',
-    version='1.0',
+    version='1.3',
     description='Builds a CUTEst test function interface for Python.',
     long_description='Builds a CUTEst test function interface for Python.',
     author='Arpad Buermen, Jaroslav Fowkes, Lindon Roberts',
@@ -101,7 +95,7 @@ extra_link_args=['-Wl,-no_compact_unwind']
 
 
 def get_setup_script():
-    if sys.platform in ["linux", "linux2"]:
+    if sys.platform == "linux":
         return setupScript % setupScriptLinux
     else:
         return setupScript % setupScriptMac

--- a/pycutest/install_scripts.py
+++ b/pycutest/install_scripts.py
@@ -75,7 +75,7 @@ setup(
 #
 setupScriptLinux="""
 define_macros=[('LINUX', None)]
-include_dirs=[os.path.join(np.get_include(), 'numpy'),os.environ['CUTEST']+'/include/']
+include_dirs=[np.get_include(),os.environ['CUTEST']+'/include/']
 objFileList=glob('*.o')
 objFileList.append(os.environ['CUTEST']+'/objects/'+os.environ['MYARCH']+'/double/libcutest.a')
 libraries=['gfortran']
@@ -91,7 +91,7 @@ import subprocess
 # extract the homebrew prefix 
 homebrew_prefix = subprocess.check_output(['brew', '--prefix']).decode('utf-8')[:-1]
 define_macros=[('LINUX', None)]
-include_dirs=[os.path.join(np.get_include(), 'numpy'),os.environ['CUTEST']+'/include/']
+include_dirs=[np.get_include(),os.environ['CUTEST']+'/include/']
 objFileList=glob('*.o')
 objFileList.append('%s')
 libraries=['gfortran']

--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -2,9 +2,6 @@
 A class to store problem info, where we can set up the interface exactly how we wish
 """
 
-# Ensure compatibility with Python 2
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 
 __all__ = ['CUTEstProblem']

--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -259,7 +259,6 @@ class CUTEstProblem(object):
         """
         self.check_input_x(x)
         f, c = self._module.objcons(self.free_to_all(x))
-        f = float(f)  # convert from 1x1 NumPy array to float
         if len(c) == 0:  # unconstrained problems
             c = None
         return f, c
@@ -287,11 +286,9 @@ class CUTEstProblem(object):
         self.check_input_x(x)
         if gradient:
             f, g = self._module.obj(self.free_to_all(x), 1)
-            f = float(f)  # convert from 1x1 NumPy array to float
             return f, self.all_to_free(g)
         else:
             f = self._module.obj(self.free_to_all(x))
-            f = float(f)  # convert from 1x1 NumPy array to float
             return f
 
     def cons(self, x, index=None, gradient=False):

--- a/pycutest/python_interface.py
+++ b/pycutest/python_interface.py
@@ -9,7 +9,7 @@ __all__ = ['get_init_script']
 
 initScript = """# PyCutest problem interface module initialization file
 # (C)2011 Arpad Buermen
-# (C)2018 Jaroslav Fowkes, Lindon Roberts
+# (C)2022 Jaroslav Fowkes, Lindon Roberts
 # Licensed under GNU GPL V3
 
 \"\"\"Interface module for CUTEst problem [problemName] with ordering
@@ -41,9 +41,6 @@ gradsphess -- gradient and sparse Hessian of objective (unconstrained probl.)
               constraints and sparse Hessian of Lagrangian (constrained probl.)
 report     -- get usage statistics
 \"\"\"
-
-# Ensure compatibility with Python 2
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 from ._pycutestitf import *
 from . import _pycutestitf

--- a/pycutest/sifdecode_extras.py
+++ b/pycutest/sifdecode_extras.py
@@ -2,9 +2,6 @@
 Wrapper to other SIF information - classifications, available parameters
 """
 
-# Ensure compatibility with Python 2
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os, re
 import subprocess
 from glob import iglob

--- a/pycutest/system_paths.py
+++ b/pycutest/system_paths.py
@@ -2,9 +2,6 @@
 Depending on the platform, find the correct paths to the CUTEst installation
 """
 
-# Ensure compatibility with Python 2
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os, sys
 
 __all__ = ['check_platform', 'get_cutest_path', 'get_sifdecoder_path', 'get_mastsif_path', 'get_cache_path']
@@ -13,7 +10,7 @@ __all__ = ['check_platform', 'get_cutest_path', 'get_sifdecoder_path', 'get_mast
 base_dir = os.getcwd()
 
 def check_platform():
-    if sys.platform not in ['linux', 'linux2', 'darwin']:
+    if sys.platform not in ['linux', 'darwin']:
         raise ImportError("Unsupported platform: " + sys.platform)
     return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-numpy>=1.11; python_version>="3"
-scipy>=0.18; python_version>="3"
-numpy>=1.11,<1.17; python_version<"3"
-scipy>=0.18,<1.3; python_version<"3"
+numpy>=1.11
+scipy>=0.18

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'Operating System :: MacOS',
         'Operating System :: Unix',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Mathematics',


### PR DESCRIPTION
Some much-needed modernisation of the C interface in `c_interface.py`.

I appreciate this is difficult to review for those unfamiliar with the Python C API so I will summarise the changes here (see the bottom for references):
- use canonical NumPy include paths
- drop Python 2 support as it is EOL
- warn if using NumPy C API calls that are deprecated in version 1.20
- drop all PYDEBUG print statements (these were just polluting the code)
- use `PyDoc_STRVAR` for the docstrings (as is recommended)
- use `Py_BuildValue` to create all Tuple return objects (automatically handles reference counts)
- return floats as floats not 1D NumPy arrays

References:
Python C Extensions: https://docs.python.org/3/extending/index.html
Python C API Reference: https://docs.python.org/3/c-api/index.html
NumPy C API (esp. Array API): https://numpy.org/doc/stable/reference/c-api/index.html