### PR TITLE
Fix memory leak

### DIFF
--- a/pycutest/c_interface.py
+++ b/pycutest/c_interface.py
@@ -80,6 +80,7 @@ static PyObject *cutest__sphess(PyObject *self, PyObject *args);
 static PyObject *cutest__isphess(PyObject *self, PyObject *args);
 static PyObject *cutest__gradsphess(PyObject *self, PyObject *args);
 static PyObject *cutest_report(PyObject *self, PyObject *args);
+static PyObject *cutest_terminate(PyObject *self, PyObject *args);
 
 /* Persistent data */
 #define STR_LEN 10
@@ -2052,6 +2053,34 @@ static PyObject *cutest_report(PyObject *self, PyObject *args) {
     return decRefDict(dict);
 }
 
+PyDoc_STRVAR(cutest_terminate_doc,
+"Deallocate all internal private storage.\n"
+"\n"
+"terminate()\n"
+"\n"
+"CUTEst tools used: CUTEST_cterminate, CUTEST_uterminate\n"
+);
+
+static PyObject *cutest_terminate(PyObject *self, PyObject *args) {
+
+    if (!check_setup())
+        return NULL;
+
+    if (PyObject_Length(args)!=0) {
+        PyErr_SetString(PyExc_Exception, "terminate() takes no arguments");
+        return NULL;
+    }
+
+    if (CUTEst_ncon>0)
+        CUTEST_cterminate((integer *)&status);
+    else
+        CUTEST_uterminate((integer *)&status);
+
+    /* Return None boilerplate */
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
 /* Methods table */
 static PyMethodDef _methods[] = {
     {"_dims", cutest__dims, METH_VARARGS, cutest__dims_doc},
@@ -2073,6 +2102,7 @@ static PyMethodDef _methods[] = {
     {"_isphess", cutest__isphess, METH_VARARGS, cutest__isphess_doc},
     {"_gradsphess", cutest__gradsphess, METH_VARARGS, cutest__gradsphess_doc},
     {"report", cutest_report, METH_VARARGS, cutest_report_doc},
+    {"terminate", cutest_terminate, METH_VARARGS, cutest_terminate_doc},
     {NULL, NULL}     /* Marks the end of this structure */
 };
 

--- a/pycutest/c_interface.py
+++ b/pycutest/c_interface.py
@@ -61,10 +61,10 @@ extern "C" {
 
 
 /* Prototypes */
-static PyObject *cutest__dims(PyObject *self, PyObject *args);
-static PyObject *cutest__setup(PyObject *self, PyObject *args);
-static PyObject *cutest__varnames(PyObject *self, PyObject *args);
-static PyObject *cutest__connames(PyObject *self, PyObject *args);
+static PyObject *cutest_dims(PyObject *self, PyObject *args);
+static PyObject *cutest_setup(PyObject *self, PyObject *args);
+static PyObject *cutest_varnames(PyObject *self, PyObject *args);
+static PyObject *cutest_connames(PyObject *self, PyObject *args);
 static PyObject *cutest_objcons(PyObject *self, PyObject *args);
 static PyObject *cutest_obj(PyObject *self, PyObject *args);
 static PyObject *cutest_cons(PyObject *self, PyObject *args);
@@ -74,11 +74,11 @@ static PyObject *cutest_hess(PyObject *self, PyObject *args);
 static PyObject *cutest_ihess(PyObject *self, PyObject *args);
 static PyObject *cutest_hprod(PyObject *self, PyObject *args);
 static PyObject *cutest_gradhess(PyObject *self, PyObject *args);
-static PyObject *cutest__scons(PyObject *self, PyObject *args);
-static PyObject *cutest__slagjac(PyObject *self, PyObject *args);
-static PyObject *cutest__sphess(PyObject *self, PyObject *args);
-static PyObject *cutest__isphess(PyObject *self, PyObject *args);
-static PyObject *cutest__gradsphess(PyObject *self, PyObject *args);
+static PyObject *cutest_scons(PyObject *self, PyObject *args);
+static PyObject *cutest_slagjac(PyObject *self, PyObject *args);
+static PyObject *cutest_sphess(PyObject *self, PyObject *args);
+static PyObject *cutest_isphess(PyObject *self, PyObject *args);
+static PyObject *cutest_gradsphess(PyObject *self, PyObject *args);
 static PyObject *cutest_report(PyObject *self, PyObject *args);
 static PyObject *cutest_terminate(PyObject *self, PyObject *args);
 
@@ -261,10 +261,10 @@ void extract_sparse_hessian(npy_int nnzho, npy_int *si, npy_int *sj, npy_double 
 
 /* Functions */
 
-static char cutest__dims_doc[]=
+static char cutest_dims_doc[]=
 "Returns the dimension of the problem and the number of constraints.\n"
 "\n"
-"(n, m)=_dims()\n"
+"(n, m)=dims()\n"
 "\n"
 "Output\n"
 "n -- number of variables\n"
@@ -277,9 +277,9 @@ static char cutest__dims_doc[]=
 "\n"
 "CUTEst tools used: CUTEST_cdimen\n";
 
-static PyObject *cutest__dims(PyObject *self, PyObject *args) {
+static PyObject *cutest_dims(PyObject *self, PyObject *args) {
     if (PyObject_Length(args)!=0)
-        PyErr_SetString(PyExc_Exception, "_dims() takes no arguments");
+        PyErr_SetString(PyExc_Exception, "dims() takes no arguments");
 
     if (!open_datafile())
         return NULL;
@@ -296,10 +296,10 @@ static PyObject *cutest__dims(PyObject *self, PyObject *args) {
 }
 
 
-static char cutest__setup_doc[]=
+static char cutest_setup_doc[]=
 "Sets up the problem.\n"
 "\n"
-"data=_setup(efirst, lfirst, nvfirst)\n"
+"data=setup(efirst, lfirst, nvfirst)\n"
 "\n"
 "Input\n"
 "efirst  -- if True, equation constraints are ordered before inequations.\n"
@@ -341,7 +341,7 @@ static char cutest__setup_doc[]=
 "-1e+20 and 1e+20 in bl, bu, cl, and cu stand for -infinity and +infinity.\n"
 "\n"
 "This function must be called before any other CUTEst function is called.\n"
-"The only exception is the _dims() function.\n"
+"The only exception is the dims() function.\n"
 "\n"
 "This function is not supposed to be called by the user. It is called by the\n"
 "__init__.py script when the test function interface is loaded.\n"
@@ -351,7 +351,7 @@ static char cutest__setup_doc[]=
 "CUTEst tools used: CUTEST_cdimen, CUTEST_csetup, CUTEST_usetup, CUTEST_cvartype, CUTEST_uvartype, \n"
 "                  CUTEST_cdimsh, CUTEST_udimsh, CUTEST_cdimsj, CUTEST_probname\n";
 
-static PyObject *cutest__setup(PyObject *self, PyObject *args) {
+static PyObject *cutest_setup(PyObject *self, PyObject *args) {
     npy_bool  efirst = FALSE_, lfirst = FALSE_, nvfrst = FALSE_;
     int eFirst, lFirst, nvFirst;
     PyObject *dict;
@@ -364,7 +364,7 @@ static PyObject *cutest__setup(PyObject *self, PyObject *args) {
     int i;
 
     if (PyObject_Length(args)!=0 && PyObject_Length(args)!=3) {
-        PyErr_SetString(PyExc_Exception, "_setup() takes 0 or 3 arguments");
+        PyErr_SetString(PyExc_Exception, "setup() takes 0 or 3 arguments");
         return NULL;
     }
 
@@ -516,22 +516,22 @@ static PyObject *cutest__setup(PyObject *self, PyObject *args) {
 }
 
 
-static char cutest__varnames_doc[]=
+static char cutest_varnames_doc[]=
 "Returns the names of variables in the problem.\n"
 "\n"
-"namelist=_varnames()\n"
+"namelist=varnames()\n"
 "\n"
 "Output\n"
 "namelist -- list of length n holding strings holding names of variables\n"
 "\n"
-"The list reflects the ordering imposed by the nvfirst argument to _setup().\n"
+"The list reflects the ordering imposed by the nvfirst argument to setup().\n"
 "\n"
 "This function is not supposed to be called by the user. It is called by the\n"
 "__init__.py script when the test function interface is loaded.\n"
 "\n"
 "CUTEst tools used: CUTEST_varnames\n";
 
-static PyObject *cutest__varnames(PyObject *self, PyObject *args) {
+static PyObject *cutest_varnames(PyObject *self, PyObject *args) {
     char *Fvnames, Fvname[STR_LEN+1], *ptr;
     PyObject *list;
     int i, j;
@@ -543,7 +543,7 @@ static PyObject *cutest__varnames(PyObject *self, PyObject *args) {
         return NULL;
 
     if (PyObject_Length(args)!=0) {
-        PyErr_SetString(PyExc_Exception, "_varnames() takes 0 arguments");
+        PyErr_SetString(PyExc_Exception, "varnames() takes 0 arguments");
         return NULL;
     }
 
@@ -577,23 +577,23 @@ static PyObject *cutest__varnames(PyObject *self, PyObject *args) {
 }
 
 
-static char cutest__connames_doc[]=
+static char cutest_connames_doc[]=
 "Returns the names of constraints in the problem.\n"
 "\n"
-"namelist=_connames()\n"
+"namelist=connames()\n"
 "\n"
 "Output\n"
 "namelist -- list of length m holding strings holding names of constraints\n"
 "\n"
 "The list is ordered in the way specified by efirst and lfirst arguments to\n"
-"_setup().\n"
+"setup().\n"
 "\n"
 "This function is not supposed to be called by the user. It is called by the\n"
 "__init__.py script when the test function interface is loaded.\n"
 "\n"
 "CUTEst tools used: CUTEST_connames\n";
 
-static PyObject *cutest__connames(PyObject *self, PyObject *args) {
+static PyObject *cutest_connames(PyObject *self, PyObject *args) {
     char *Fcnames, Fcname[STR_LEN+1], *ptr;
     PyObject *list;
     int i, j;
@@ -605,7 +605,7 @@ static PyObject *cutest__connames(PyObject *self, PyObject *args) {
         return NULL;
 
     if (PyObject_Length(args)!=0) {
-        PyErr_SetString(PyExc_Exception, "_connames() takes 0 arguments");
+        PyErr_SetString(PyExc_Exception, "connames() takes 0 arguments");
         return NULL;
     }
 
@@ -1444,11 +1444,11 @@ static PyObject *cutest_gradhess(PyObject *self, PyObject *args) {
 }
 
 
-static char cutest__scons_doc[]=
+static char cutest_scons_doc[]=
 "Returns the value of constraints and the sparse Jacobian of constraints at x.\n"
 "\n"
-"(c, Jvi, Jfi, Jv)=_scons(x) -- Jacobian of constraints\n"
-"(ci, gi, gv)=_scons(x, i)   -- i-th constraint and its gradient\n"
+"(c, Jvi, Jfi, Jv)=scons(x) -- Jacobian of constraints\n"
+"(ci, gi, gv)=scons(x, i)   -- i-th constraint and its gradient\n"
 "\n"
 "Input\n"
 "x -- 1D array of length n with the values of variables\n"
@@ -1475,7 +1475,7 @@ static char cutest__scons_doc[]=
 "\n"
 "CUTEst tools used: CUTEST_ccfsg, CUTEST_ccifsg\n";
 
-static PyObject *cutest__scons(PyObject *self, PyObject *args) {
+static PyObject *cutest_scons(PyObject *self, PyObject *args) {
     PyArrayObject *arg1, *Mc, *MJi, *MJfi, *MJv, *Mgi, *Mgv;
     doublereal *c, *Jv, *gv, *x, *sv;
     npy_int *Ji, *Jfi, *gi, *si;
@@ -1570,12 +1570,12 @@ static PyObject *cutest__scons(PyObject *self, PyObject *args) {
 }
 
 
-static char cutest__slagjac_doc[]=
+static char cutest_slagjac_doc[]=
 "Returns the sparse gradient of objective at x or Lagrangian at (x, v), \n"
 "and the sparse Jacobian of constraints at x.\n"
 "\n"
-"(gi, gv, Jvi, Jfi, Jv)=_slagjac(x)    -- objective gradient and Jacobian\n"
-"(gi, gv, Jvi, Jfi, Jv)=_slagjac(x, v) -- Lagrangian gradient and Jacobian\n"
+"(gi, gv, Jvi, Jfi, Jv)=slagjac(x)    -- objective gradient and Jacobian\n"
+"(gi, gv, Jvi, Jfi, Jv)=slagjac(x, v) -- Lagrangian gradient and Jacobian\n"
 "\n"
 "Input\n"
 "x -- 1D array of length n with the values of variables\n"
@@ -1598,7 +1598,7 @@ static char cutest__slagjac_doc[]=
 "\n"
 "CUTEst tools used: CUTEST_csgr\n";
 
-static PyObject *cutest__slagjac(PyObject *self, PyObject *args) {
+static PyObject *cutest_slagjac(PyObject *self, PyObject *args) {
     PyArrayObject *arg1, *arg2, *Mgi, *Mgv, *MJi, *MJfi, *MJv;
     doublereal *x, *v=NULL, *sv;
     npy_int *si, *sfi;
@@ -1666,12 +1666,12 @@ static PyObject *cutest__slagjac(PyObject *self, PyObject *args) {
 }
 
 
-static char cutest__sphess_doc[]=
+static char cutest_sphess_doc[]=
 "Returns the sparse Hessian of the objective at x (unconstrained problems) or\n"
 "the sparse Hessian of the Lagrangian (constrained problems) at (x, v).\n"
 "\n"
-"(Hi, Hj, Hv)=_sphess(x)    -- Hessian of objective (unconstrained problems)\n"
-"(Hi, Hj, Hv)=_sphess(x, v) -- Hessian of Lagrangian (constrained problems)\n"
+"(Hi, Hj, Hv)=sphess(x)    -- Hessian of objective (unconstrained problems)\n"
+"(Hi, Hj, Hv)=sphess(x, v) -- Hessian of Lagrangian (constrained problems)\n"
 "\n"
 "Input\n"
 "x -- 1D array of length n with the values of variables\n"
@@ -1687,14 +1687,14 @@ static char cutest__sphess_doc[]=
 "\n"
 "Hi, Hj, and Hv represent the full Hessian and not only the diagonal and the\n"
 "upper triangle. To obtain the Hessian of the objective of constrained\n"
-"problems use _isphess().\n"
+"problems use isphess().\n"
 "\n"
 "This function is not supposed to be called by the user. It is called by the\n"
 "wrapper function sphess().\n"
 "\n"
 "CUTEst tools used: CUTEST_csh, CUTEST_ush\n";
 
-static PyObject *cutest__sphess(PyObject *self, PyObject *args) {
+static PyObject *cutest_sphess(PyObject *self, PyObject *args) {
     PyArrayObject *arg1, *arg2, *MHi, *MHj, *MHv;
     doublereal *x, *v=NULL, *sv;
     npy_int *si, *sj, nnzho;
@@ -1723,7 +1723,7 @@ static PyObject *cutest__sphess(PyObject *self, PyObject *args) {
                 return NULL;
             }
         } else {
-            PyErr_SetString(PyExc_Exception, "Argument 2 must be specified for constrained problems. Use _isphess().");
+            PyErr_SetString(PyExc_Exception, "Argument 2 must be specified for constrained problems. Use isphess().");
             return NULL;
         }
     }
@@ -1760,12 +1760,12 @@ static PyObject *cutest__sphess(PyObject *self, PyObject *args) {
 }
 
 
-static char cutest__isphess_doc[]=
+static char cutest_isphess_doc[]=
 "Returns the sparse Hessian of the objective or the sparse Hessian of i-th\n"
 "constraint at x.\n"
 "\n"
-"(Hi, Hj, Hv)=_isphess(x)    -- Hessian of objective\n"
-"(Hi, Hj, Hv)=_isphess(x, i) -- Hessian of i-th constraint\n"
+"(Hi, Hj, Hv)=isphess(x)    -- Hessian of objective\n"
+"(Hi, Hj, Hv)=isphess(x, i) -- Hessian of i-th constraint\n"
 "\n"
 "Input\n"
 "x -- 1D array of length n with the values of variables\n"
@@ -1787,7 +1787,7 @@ static char cutest__isphess_doc[]=
 "\n"
 "CUTEst tools used: CUTEST_cish, CUTEST_ush\n";
 
-static PyObject *cutest__isphess(PyObject *self, PyObject *args) {
+static PyObject *cutest_isphess(PyObject *self, PyObject *args) {
     PyArrayObject *arg1, *MHi, *MHj, *MHv;
     doublereal *x, *sv;
     npy_int *si, *sj, nnzho, i;
@@ -1846,12 +1846,12 @@ static PyObject *cutest__isphess(PyObject *self, PyObject *args) {
 }
 
 
-static char cutest__gradsphess_doc[]=
+static char cutest_gradsphess_doc[]=
 "Returns the sparse Hessian of the Lagrangian, the sparse Jacobian of\n"
 "constraints, and the gradient of the objective or Lagrangian.\n"
 "\n"
-"(g, Hi, Hj, Hv)=_gradsphess(x) -- unconstrained problems\n"
-"(gi, gv, Jvi, Jfi, Jv, Hi, Hj, Hv)=_gradsphess(x, v, gradl)\n"
+"(g, Hi, Hj, Hv)=gradsphess(x) -- unconstrained problems\n"
+"(gi, gv, Jvi, Jfi, Jv, Hi, Hj, Hv)=gradsphess(x, v, gradl)\n"
 "                               -- constrained problems\n"
 "\n"
 "Input\n"
@@ -1889,7 +1889,7 @@ static char cutest__gradsphess_doc[]=
 "\n"
 "CUTEst tools used: CUTEST_csgrsh, CUTEST_ugrsh\n";
 
-static PyObject *cutest__gradsphess(PyObject *self, PyObject *args) {
+static PyObject *cutest_gradsphess(PyObject *self, PyObject *args) {
     PyArrayObject *arg1, *arg2, *Mg=NULL, *Mgi, *Mgv, *MJi, *MJfi, *MJv, *MHi, *MHj, *MHv;
     PyObject *arg3;
     doublereal *x, *v, *g, *sv, *sjv;
@@ -2086,10 +2086,10 @@ static PyObject *cutest_terminate(PyObject *self, PyObject *args) {
 
 /* Methods table */
 static PyMethodDef _methods[] = {
-    {"_dims", cutest__dims, METH_VARARGS, cutest__dims_doc},
-    {"_setup", cutest__setup, METH_VARARGS, cutest__setup_doc},
-    {"_varnames", cutest__varnames, METH_VARARGS, cutest__varnames_doc},
-    {"_connames", cutest__connames, METH_VARARGS, cutest__connames_doc},
+    {"dims", cutest_dims, METH_VARARGS, cutest_dims_doc},
+    {"setup", cutest_setup, METH_VARARGS, cutest_setup_doc},
+    {"varnames", cutest_varnames, METH_VARARGS, cutest_varnames_doc},
+    {"connames", cutest_connames, METH_VARARGS, cutest_connames_doc},
     {"objcons", cutest_objcons, METH_VARARGS, cutest_objcons_doc},
     {"obj", cutest_obj, METH_VARARGS, cutest_obj_doc},
     {"cons", cutest_cons, METH_VARARGS, cutest_cons_doc},
@@ -2099,11 +2099,11 @@ static PyMethodDef _methods[] = {
     {"ihess", cutest_ihess, METH_VARARGS, cutest_ihess_doc},
     {"hprod", cutest_hprod, METH_VARARGS, cutest_hprod_doc},
     {"gradhess", cutest_gradhess, METH_VARARGS, cutest_gradhess_doc},
-    {"_scons", cutest__scons, METH_VARARGS, cutest__scons_doc},
-    {"_slagjac", cutest__slagjac, METH_VARARGS, cutest__slagjac_doc},
-    {"_sphess", cutest__sphess, METH_VARARGS, cutest__sphess_doc},
-    {"_isphess", cutest__isphess, METH_VARARGS, cutest__isphess_doc},
-    {"_gradsphess", cutest__gradsphess, METH_VARARGS, cutest__gradsphess_doc},
+    {"scons", cutest_scons, METH_VARARGS, cutest_scons_doc},
+    {"slagjac", cutest_slagjac, METH_VARARGS, cutest_slagjac_doc},
+    {"sphess", cutest_sphess, METH_VARARGS, cutest_sphess_doc},
+    {"isphess", cutest_isphess, METH_VARARGS, cutest_isphess_doc},
+    {"gradsphess", cutest_gradsphess, METH_VARARGS, cutest_gradsphess_doc},
     {"report", cutest_report, METH_VARARGS, cutest_report_doc},
     {"terminate", cutest_terminate, METH_VARARGS, cutest_terminate_doc},
     {NULL, NULL}     /* Marks the end of this structure */

--- a/pycutest/c_interface.py
+++ b/pycutest/c_interface.py
@@ -2076,6 +2076,9 @@ static PyObject *cutest_terminate(PyObject *self, PyObject *args) {
     else
         CUTEST_uterminate((integer *)&status);
 
+    /* Problem is no longer set up */
+    setupCalled = 0;
+
     /* Return None boilerplate */
     Py_INCREF(Py_None);
     return Py_None;

--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -174,50 +174,6 @@ class CUTEstProblem(object):
         # Save the initial stats, so we can make sure they don't get counted in the final tally
         self.init_stats = self._module.report()
 
-    # Return problem info
-    def getinfo(self):
-        """
-        Return the problem info dictionary.
-
-        info=geinfo()
-
-        Output
-        info -- dictionary with the summary of test function's properties
-
-        The dictionary has the following members:
-        name       -- problem name
-        n          -- number of variables
-        m          -- number of constraints (excluding bounds)
-        x          -- initial point (1D array of length n)
-        bl         -- 1D array of length n with lower bounds on variables
-        bu         -- 1D array of length n with upper bounds on variables
-        nnzh       -- number of nonzero elements in the diagonal and upper triangle of
-                    sparse Hessian
-        vartype    -- 1D integer array of length n storing variable type
-                    0=real,  1=boolean (0 or 1), 2=integer
-        nvfirst    -- boolean flag indicating that nonlinear variables were placed
-                    before linear variables
-        sifparams  -- parameters passed to sifdecode with the -param option
-                    None if no parameters were given
-        sifoptions -- additional options passed to sifdecode
-                    None if no additional options were given.
-
-        For constrained problems the following additional members are available
-        nnzj    -- number of nonzero elements in sparse Jacobian of constraints
-        v       -- 1D array of length m with initial values of Lagrange multipliers
-        cl      -- 1D array of length m with lower bounds on constraint functions
-        cu      -- 1D array of length m with upper bounds on constraint functions
-        equatn  -- 1D boolean array of length m indicating whether a constraint
-                is an equation constraint
-        linear  -- 1D boolean array of length m indicating whether a constraint
-                is a linear constraint
-        efirst  -- boolean flag indicating that equation constraints were places
-                before inequation constraints
-        lfirst  -- boolean flag indicating that linear constraints were placed
-                before nonlinear constraints
-        """
-        return self._module.info
-
     def __str__(self):
         if self.sifParams is None:
             return "CUTEst problem %s (default params) with %g variables and %g constraints" % (self.name, self.n, self.m)

--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -280,7 +280,7 @@ class CUTEstProblem(object):
 
         :return: a list of strings representing the names of problem's variables (including fixed variables)
         """
-        return self._module._varnames()
+        return self._module.varnames()
 
     def connames(self):
         """
@@ -288,7 +288,7 @@ class CUTEstProblem(object):
 
         :return: a list of strings representing the names of problem constraints
         """
-        return self._module._connames()
+        return self._module.connames()
 
     def objcons(self, x):
         """
@@ -634,13 +634,13 @@ class CUTEstProblem(object):
             g, H = self._module.gradhess(self.free_to_all(x))
             return self.all_to_free(g), H[self.idx_free][:, self.idx_free]
 
-    # _scons() wrapper (private)
+    # scons() wrapper (private)
     def __scons(self, x, i=None):
         """Returns the value of constraints and
         the sparse Jacobian of constraints at x.
 
-        (c, J)=_scons(x)      -- Jacobian of constraints
-        (ci, gi)=_scons(x, i) -- i-th constraint and its gradient
+        (c, J)=__scons(x)      -- Jacobian of constraints
+        (ci, gi)=__scons(x, i) -- i-th constraint and its gradient
 
         Input
         x -- 1D array of length n with the values of variables
@@ -652,14 +652,14 @@ class CUTEstProblem(object):
         ci -- 1D array of length 1 holding the value of i-th constraint at x
         gi -- a scipy.sparse.coo_matrix of size 1-by-n holding the gradient of i-th constraint at x
 
-        This function is a wrapper for _scons().
+        This function is a wrapper for scons().
         """
 
         if i is None:
-            (c, Ji, Jif, Jv)=self._module._scons(x)
+            (c, Ji, Jif, Jv)=self._module.scons(x)
             return (c, coo_matrix((Jv, (Jif, Ji)), shape=(self.m, self.n)))
         else:
-            (c, gi, gv)=self._module._scons(x, i)
+            (c, gi, gv)=self._module.scons(x, i)
             return (c, coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n)))
 
     def scons(self, x, index=None, gradient=False):
@@ -712,13 +712,13 @@ class CUTEstProblem(object):
             else:
                 return ci
 
-    # _slagjac() wrapper
+    # slagjac() wrapper
     def __slagjac(self, x, v=None):
         """Returns the sparse gradient of objective at x or Lagrangian at (x, v),
         and the sparse Jacobian of constraints at x.
 
-        (g, J)=_slagjac(x)    -- objective gradient and Jacobian
-        (g, J)=_slagjac(x, v) -- Lagrangian gradient and Jacobian
+        (g, J)=__slagjac(x)    -- objective gradient and Jacobian
+        (g, J)=__slagjac(x, v) -- Lagrangian gradient and Jacobian
 
         Input
         x -- 1D array of length n with the values of variables
@@ -730,13 +730,13 @@ class CUTEstProblem(object):
         J -- a scipy.sparse.coo_matrix of size m-by-n holding the sparse Jacobian
             of constraints at x
 
-        This function is a wrapper for _slagjac().
+        This function is a wrapper for slagjac().
         """
 
         if v is None:
-            (gi, gv, Ji, Jfi, Jv)=self._module._slagjac(x)
+            (gi, gv, Ji, Jfi, Jv)=self._module.slagjac(x)
         else:
-            (gi, gv, Ji, Jfi, Jv)=self._module._slagjac(x, v)
+            (gi, gv, Ji, Jfi, Jv)=self._module.slagjac(x, v)
         return (
             coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n)),
             coo_matrix((Jv, (Jfi, Ji)), shape=(self.m, self.n))
@@ -781,13 +781,13 @@ class CUTEstProblem(object):
         else:
             return sparse_vec_extract_indices(g, self.idx_free), None
 
-    # _sphess() wrapper (private)
+    # sphess() wrapper (private)
     def __sphess(self, x, v=None):
         """Returns the sparse Hessian of the objective at x (unconstrained problems)
         or the sparse Hessian of the Lagrangian (constrained problems) at (x, v).
 
-        H=_sphess(x)    -- Hessian of objective (unconstrained problems)
-        H=_sphess(x, v) -- Hessian of Lagrangian (constrained problems)
+        H=__sphess(x)    -- Hessian of objective (unconstrained problems)
+        H=__sphess(x, v) -- Hessian of Lagrangian (constrained problems)
 
         Input
         x -- 1D array of length n with the values of variables
@@ -797,13 +797,13 @@ class CUTEstProblem(object):
         H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
             of objective at x or the sparse Hessian of the Lagrangian at (x, v)
 
-        This function is a wrapper for _sphess().
+        This function is a wrapper for sphess().
         """
 
         if v is None:
-            (Hi, Hj, Hv)=self._module._sphess(x)
+            (Hi, Hj, Hv)=self._module.sphess(x)
         else:
-            (Hi, Hj, Hv)=self._module._sphess(x, v)
+            (Hi, Hj, Hv)=self._module.sphess(x, v)
         return coo_matrix((Hv, (Hi, Hj)), shape=(self.n, self.n))
 
     def sphess(self, x, v=None):
@@ -847,13 +847,13 @@ class CUTEstProblem(object):
             H = self.__sphess(self.free_to_all(x), v)
         return sparse_mat_extract_rows_and_columns(H, self.idx_free, self.idx_free)
 
-    # _isphess() wrapper (private)
+    # isphess() wrapper (private)
     def __isphess(self, x, i=None):
         """Returns the sparse Hessian of the objective or the sparse Hessian of i-th
         constraint at x.
 
-        H=_isphess(x)    -- Hessian of objective
-        H=_isphess(x, i) -- Hessian of i-th constraint
+        H=__isphess(x)    -- Hessian of objective
+        H=__isphess(x, i) -- Hessian of i-th constraint
 
         Input
         x -- 1D array of length n with the values of variables
@@ -863,13 +863,13 @@ class CUTEstProblem(object):
         H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
             of objective or the sparse Hessian i-th constraint at x
 
-        This function is a wrapper for _isphess().
+        This function is a wrapper for isphess().
         """
 
         if i is None:
-            (Hi, Hj, Hv)=self._module._isphess(x)
+            (Hi, Hj, Hv)=self._module.isphess(x)
         else:
-            (Hi, Hj, Hv)=self._module._isphess(x, i)
+            (Hi, Hj, Hv)=self._module.isphess(x, i)
         return coo_matrix((Hv, (Hi, Hj)), shape=(self.n, self.n))
 
     def isphess(self, x, cons_index=None):
@@ -905,13 +905,13 @@ class CUTEstProblem(object):
             H = self.__isphess(self.free_to_all(x), cons_index)
         return sparse_mat_extract_rows_and_columns(H, self.idx_free, self.idx_free)
 
-    # _gradsphess() wrapper (private)
+    # gradsphess() wrapper (private)
     def __gradsphess(self, x, v=None, lagrFlag=False):
         """Returns the sparse Hessian of the Lagrangian, the sparse Jacobian of
         constraints, and the gradient of the objective or Lagrangian.
 
-        (g, H)=gradsphess(x)              -- unconstrained problems
-        (g, J, H)=gradsphess(x, v, gradl) -- constrained problems
+        (g, H)=__gradsphess(x)              -- unconstrained problems
+        (g, J, H)=__gradsphess(x, v, gradl) -- constrained problems
 
         Input
         x     -- 1D array of length n with the values of variables
@@ -928,14 +928,14 @@ class CUTEstProblem(object):
         H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
             of objective at x or the sparse Hessian of the Lagrangian at (x, v)
 
-        This function is a wrapper for _gradsphess().
+        This function is a wrapper for gradsphess().
         """
 
         if v is None:
-            (g, Hi, Hj, Hv)=self._module._gradsphess(x)
+            (g, Hi, Hj, Hv)=self._module.gradsphess(x)
             return (coo_matrix(g), coo_matrix((Hv, (Hi, Hj)), shape=(self.n, self.n)))
         else:
-            (gi, gv, Ji, Jfi, Jv, Hi, Hj, Hv)=self._module._gradsphess(x, v, lagrFlag)
+            (gi, gv, Ji, Jfi, Jv, Hi, Hj, Hv)=self._module.gradsphess(x, v, lagrFlag)
             return (
                 coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n)),
                 coo_matrix((Jv, (Jfi, Ji)), shape=(self.m, self.n)),

--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -834,3 +834,10 @@ class CUTEstProblem(object):
                 stats[s] = stats[s] - self.init_stats[s]
 
         return stats
+
+    def __del__(self):
+        """
+        Clear CUTEst problem memory on exit.
+        """
+        self._module.terminate()
+

--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -6,6 +6,7 @@ A class to store problem info, where we can set up the interface exactly how we 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
+from scipy.sparse import coo_matrix
 
 __all__ = ['CUTEstProblem']
 
@@ -76,6 +77,9 @@ class CUTEstProblem(object):
         """
         self._module = module
         self.drop_fixed_vars = drop_fixed_variables
+
+        # Initialise CUTEst problem
+        self._module.info = self._module.setup()
 
         # Extract useful problem info
 
@@ -170,6 +174,50 @@ class CUTEstProblem(object):
         # Save the initial stats, so we can make sure they don't get counted in the final tally
         self.init_stats = self._module.report()
 
+    # Return problem info
+    def getinfo(self):
+        """
+        Return the problem info dictionary.
+
+        info=geinfo()
+
+        Output
+        info -- dictionary with the summary of test function's properties
+
+        The dictionary has the following members:
+        name       -- problem name
+        n          -- number of variables
+        m          -- number of constraints (excluding bounds)
+        x          -- initial point (1D array of length n)
+        bl         -- 1D array of length n with lower bounds on variables
+        bu         -- 1D array of length n with upper bounds on variables
+        nnzh       -- number of nonzero elements in the diagonal and upper triangle of
+                    sparse Hessian
+        vartype    -- 1D integer array of length n storing variable type
+                    0=real,  1=boolean (0 or 1), 2=integer
+        nvfirst    -- boolean flag indicating that nonlinear variables were placed
+                    before linear variables
+        sifparams  -- parameters passed to sifdecode with the -param option
+                    None if no parameters were given
+        sifoptions -- additional options passed to sifdecode
+                    None if no additional options were given.
+
+        For constrained problems the following additional members are available
+        nnzj    -- number of nonzero elements in sparse Jacobian of constraints
+        v       -- 1D array of length m with initial values of Lagrange multipliers
+        cl      -- 1D array of length m with lower bounds on constraint functions
+        cu      -- 1D array of length m with upper bounds on constraint functions
+        equatn  -- 1D boolean array of length m indicating whether a constraint
+                is an equation constraint
+        linear  -- 1D boolean array of length m indicating whether a constraint
+                is a linear constraint
+        efirst  -- boolean flag indicating that equation constraints were places
+                before inequation constraints
+        lfirst  -- boolean flag indicating that linear constraints were placed
+                before nonlinear constraints
+        """
+        return self._module.info
+
     def __str__(self):
         if self.sifParams is None:
             return "CUTEst problem %s (default params) with %g variables and %g constraints" % (self.name, self.n, self.m)
@@ -232,7 +280,7 @@ class CUTEstProblem(object):
 
         :return: a list of strings representing the names of problem's variables (including fixed variables)
         """
-        return self._module.varnames()
+        return self._module._varnames()
 
     def connames(self):
         """
@@ -240,7 +288,7 @@ class CUTEstProblem(object):
 
         :return: a list of strings representing the names of problem constraints
         """
-        return self._module.connames()
+        return self._module._connames()
 
     def objcons(self, x):
         """
@@ -586,6 +634,34 @@ class CUTEstProblem(object):
             g, H = self._module.gradhess(self.free_to_all(x))
             return self.all_to_free(g), H[self.idx_free][:, self.idx_free]
 
+    # _scons() wrapper (private)
+    def __scons(self, x, i=None):
+        """Returns the value of constraints and
+        the sparse Jacobian of constraints at x.
+
+        (c, J)=_scons(x)      -- Jacobian of constraints
+        (ci, gi)=_scons(x, i) -- i-th constraint and its gradient
+
+        Input
+        x -- 1D array of length n with the values of variables
+        i -- integer index of constraint (between 0 and m-1)
+
+        Output
+        c  -- 1D array of length m holding the values of constraints at x
+        J  -- a scipy.sparse.coo_matrix of size m-by-n holding the Jacobian at x
+        ci -- 1D array of length 1 holding the value of i-th constraint at x
+        gi -- a scipy.sparse.coo_matrix of size 1-by-n holding the gradient of i-th constraint at x
+
+        This function is a wrapper for _scons().
+        """
+
+        if i is None:
+            (c, Ji, Jif, Jv)=self._module._scons(x)
+            return (c, coo_matrix((Jv, (Jif, Ji)), shape=(self.m, self.n)))
+        else:
+            (c, gi, gv)=self._module._scons(x, i)
+            return (c, coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n)))
+
     def scons(self, x, index=None, gradient=False):
         """
         Evaluate the constraints (and optionally their sparse Jacobian or gradient).
@@ -622,19 +698,49 @@ class CUTEstProblem(object):
             return None
         self.check_input_x(x)
         if index is None:
-            c, J = self._module.scons(self.free_to_all(x))
+            c, J = self.__scons(self.free_to_all(x))
             if gradient:
                 return c, sparse_mat_extract_columns(J, self.idx_free)
             else:
                 return c
         else:
             assert 0 <= index <= self.m - 1, "Invalid constraint index %g (must be in 0..%g)" % (index, self.m - 1)
-            ci, Ji = self._module.scons(self.free_to_all(x), index)
+            ci, Ji = self.__scons(self.free_to_all(x), index)
             ci = float(ci)  # convert from 1x1 NumPy array to float
             if gradient:
                 return ci, sparse_vec_extract_indices(Ji, self.idx_free)
             else:
                 return ci
+
+    # _slagjac() wrapper
+    def __slagjac(self, x, v=None):
+        """Returns the sparse gradient of objective at x or Lagrangian at (x, v),
+        and the sparse Jacobian of constraints at x.
+
+        (g, J)=_slagjac(x)    -- objective gradient and Jacobian
+        (g, J)=_slagjac(x, v) -- Lagrangian gradient and Jacobian
+
+        Input
+        x -- 1D array of length n with the values of variables
+        v -- 1D array of length m with the values of Lagrange multipliers
+
+        Output
+        g -- a scipy.sparse.coo_matrix of size 1-by-n holding the gradient of objective at x or
+            the gradient of Lagrangian at (x, v)
+        J -- a scipy.sparse.coo_matrix of size m-by-n holding the sparse Jacobian
+            of constraints at x
+
+        This function is a wrapper for _slagjac().
+        """
+
+        if v is None:
+            (gi, gv, Ji, Jfi, Jv)=self._module._slagjac(x)
+        else:
+            (gi, gv, Ji, Jfi, Jv)=self._module._slagjac(x, v)
+        return (
+            coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n)),
+            coo_matrix((Jv, (Jfi, Ji)), shape=(self.m, self.n))
+        )
 
     def slagjac(self, x, v=None):
         """
@@ -666,14 +772,39 @@ class CUTEstProblem(object):
         """
         self.check_input_x(x)
         if v is None:
-            g, J = self._module.slagjac(self.free_to_all(x))
+            g, J = self.__slagjac(self.free_to_all(x))
         else:
             self.check_input_v(v)
-            g, J = self._module.slagjac(self.free_to_all(x), v)
+            g, J = self.__slagjac(self.free_to_all(x), v)
         if self.m > 0:
             return sparse_vec_extract_indices(g, self.idx_free), sparse_mat_extract_columns(J, self.idx_free)
         else:
             return sparse_vec_extract_indices(g, self.idx_free), None
+
+    # _sphess() wrapper (private)
+    def __sphess(self, x, v=None):
+        """Returns the sparse Hessian of the objective at x (unconstrained problems)
+        or the sparse Hessian of the Lagrangian (constrained problems) at (x, v).
+
+        H=_sphess(x)    -- Hessian of objective (unconstrained problems)
+        H=_sphess(x, v) -- Hessian of Lagrangian (constrained problems)
+
+        Input
+        x -- 1D array of length n with the values of variables
+        v -- 1D array of length m with the values of Lagrange multipliers
+
+        Output
+        H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
+            of objective at x or the sparse Hessian of the Lagrangian at (x, v)
+
+        This function is a wrapper for _sphess().
+        """
+
+        if v is None:
+            (Hi, Hj, Hv)=self._module._sphess(x)
+        else:
+            (Hi, Hj, Hv)=self._module._sphess(x, v)
+        return coo_matrix((Hv, (Hi, Hj)), shape=(self.n, self.n))
 
     def sphess(self, x, v=None):
         """
@@ -710,11 +841,36 @@ class CUTEstProblem(object):
         if self.m > 0:
             assert v is not None, "CUTEstProblem.sphess: v must be specified for constrained problems. For the objective Hessian, use problem.isphess(x)"
             self.check_input_v(v)
-            H = self._module.sphess(self.free_to_all(x), v)
+            H = self.__sphess(self.free_to_all(x), v)
         else:
             assert v is None, "CUTEstProblem.sphess: v must be None for unconstrained problems"
-            H = self._module.sphess(self.free_to_all(x), v)
+            H = self.__sphess(self.free_to_all(x), v)
         return sparse_mat_extract_rows_and_columns(H, self.idx_free, self.idx_free)
+
+    # _isphess() wrapper (private)
+    def __isphess(self, x, i=None):
+        """Returns the sparse Hessian of the objective or the sparse Hessian of i-th
+        constraint at x.
+
+        H=_isphess(x)    -- Hessian of objective
+        H=_isphess(x, i) -- Hessian of i-th constraint
+
+        Input
+        x -- 1D array of length n with the values of variables
+        i -- integer holding the index of constraint (between 0 and m-1)
+
+        Output
+        H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
+            of objective or the sparse Hessian i-th constraint at x
+
+        This function is a wrapper for _isphess().
+        """
+
+        if i is None:
+            (Hi, Hj, Hv)=self._module._isphess(x)
+        else:
+            (Hi, Hj, Hv)=self._module._isphess(x, i)
+        return coo_matrix((Hv, (Hi, Hj)), shape=(self.n, self.n))
 
     def isphess(self, x, cons_index=None):
         """
@@ -742,12 +898,49 @@ class CUTEstProblem(object):
         """
         self.check_input_x(x)
         if cons_index is None:
-            H = self._module.isphess(self.free_to_all(x))
+            H = self.__isphess(self.free_to_all(x))
         else:
             assert 0 <= cons_index <= self.m - 1, "Invalid constraint index %g (must be in 0..%g)" % (
             cons_index, self.m - 1)
-            H = self._module.isphess(self.free_to_all(x), cons_index)
+            H = self.__isphess(self.free_to_all(x), cons_index)
         return sparse_mat_extract_rows_and_columns(H, self.idx_free, self.idx_free)
+
+    # _gradsphess() wrapper (private)
+    def __gradsphess(self, x, v=None, lagrFlag=False):
+        """Returns the sparse Hessian of the Lagrangian, the sparse Jacobian of
+        constraints, and the gradient of the objective or Lagrangian.
+
+        (g, H)=gradsphess(x)              -- unconstrained problems
+        (g, J, H)=gradsphess(x, v, gradl) -- constrained problems
+
+        Input
+        x     -- 1D array of length n with the values of variables
+        v     -- 1D array of length m with the values of Lagrange multipliers
+        gradl -- boolean flag. If False the gradient of the objective is returned,
+                if True the gradient of the Lagrangian is returned.
+                Default is False
+
+        Output
+        g -- a scipy.sparse.coo_matrix of size 1-by-n holding the gradient of objective at x or
+            the gradient of Lagrangian at (x, v)
+        J -- a scipy.sparse.coo_matrix of size m-by-n holding the sparse Jacobian
+            of constraints at x
+        H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
+            of objective at x or the sparse Hessian of the Lagrangian at (x, v)
+
+        This function is a wrapper for _gradsphess().
+        """
+
+        if v is None:
+            (g, Hi, Hj, Hv)=self._module._gradsphess(x)
+            return (coo_matrix(g), coo_matrix((Hv, (Hi, Hj)), shape=(self.n, self.n)))
+        else:
+            (gi, gv, Ji, Jfi, Jv, Hi, Hj, Hv)=self._module._gradsphess(x, v, lagrFlag)
+            return (
+                coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n)),
+                coo_matrix((Jv, (Jfi, Ji)), shape=(self.m, self.n)),
+                coo_matrix((Hv, (Hi, Hj)), shape=(self.n, self.n))
+            )
 
     def gradsphess(self, x, v=None, gradient_of_lagrangian=True):
         """
@@ -786,12 +979,12 @@ class CUTEstProblem(object):
         self.check_input_x(x)
         self.check_input_v(v)
         if self.m > 0:
-            g, J, H = self._module.gradsphess(self.free_to_all(x), v, gradient_of_lagrangian)
+            g, J, H = self.__gradsphess(self.free_to_all(x), v, gradient_of_lagrangian)
             return sparse_vec_extract_indices(g, self.idx_free), \
                    sparse_mat_extract_columns(J, self.idx_free), \
                    sparse_mat_extract_rows_and_columns(H, self.idx_free, self.idx_free)
         else:
-            g, H = self._module.gradsphess(self.free_to_all(x))
+            g, H = self.__gradsphess(self.free_to_all(x))
             return sparse_vec_extract_indices(g, self.idx_free), sparse_mat_extract_rows_and_columns(H, self.idx_free, self.idx_free)
 
     def report(self):

--- a/pycutest/python_interface.py
+++ b/pycutest/python_interface.py
@@ -17,11 +17,11 @@ initScript = """# PyCutest problem interface module initialization file
 sifdecode parameters : [sifParamsStr]
 sifdecode options    : [sifOptionsStr]
 
-Available interface functions (those starting with an underscore should be wrapped)
+Available interface functions
 setup       -- setup problem and get problem information
-_dims       -- get problem dimensions
-_varnames   -- get names of problem's variables
-_connames   -- get names of problem's constraints
+dims       -- get problem dimensions
+varnames   -- get names of problem's variables
+connames   -- get names of problem's constraints
 objcons     -- objective and constraints
 obj         -- objective and objective gradient
 cons        -- constraints and constraints gradients/Jacobian
@@ -33,11 +33,11 @@ hprod       -- product of Hessian of objective/Lagrangian with a vector
 gradhess    -- gradient and Hessian of objective (unconstrained problems) or
                gradient of objective/Lagrangian, Jacobian of constraints and
                Hessian of Lagrangian (constrained problems)
-_scons      -- constraints and sparse Jacobian of constraints
-_slagjac    -- gradient of objective/Lagrangian and sparse Jacobian
-_sphess     -- sparse Hessian of objective/Lagrangian
-_isphess    -- sparse Hessian of objective/constraint
-_gradsphess -- gradient and sparse Hessian of objective (unconstrained probl.)
+scons      -- constraints and sparse Jacobian of constraints
+slagjac    -- gradient of objective/Lagrangian and sparse Jacobian
+sphess     -- sparse Hessian of objective/Lagrangian
+isphess    -- sparse Hessian of objective/constraint
+gradsphess -- gradient and sparse Hessian of objective (unconstrained probl.)
                or gradient of objective/Lagrangian, sparse Jacobian of
                constraints and sparse Hessian of Lagrangian (constrained probl.)
 report      -- get usage statistics
@@ -78,10 +78,10 @@ def setup():
     os.chdir(_directory)
 
     # Get problem dimension
-    (n, m)=_pycutestitf._dims()
+    (n, m)=_pycutestitf.dims()
 
     # Set up the problem and get basic information
-    info=_pycutestitf._setup(efirst, lfirst, nvfirst)
+    info=_pycutestitf.setup(efirst, lfirst, nvfirst)
 
     # Store constraint and variable ordering information
     if m>0:

--- a/pycutest/python_interface.py
+++ b/pycutest/python_interface.py
@@ -17,7 +17,7 @@ initScript = """# PyCutest problem interface module initialization file
 sifdecode parameters : [sifParamsStr]
 sifdecode options    : [sifOptionsStr]
 
-Available interface functions
+Available interface functions (should not be called directly):
 setup       -- setup problem and get problem information
 dims       -- get problem dimensions
 varnames   -- get names of problem's variables

--- a/pycutest/python_interface.py
+++ b/pycutest/python_interface.py
@@ -17,30 +17,31 @@ initScript = """# PyCutest problem interface module initialization file
 sifdecode parameters : [sifParamsStr]
 sifdecode options    : [sifOptionsStr]
 
-Available functions
-getinfo    -- get problem information
-varnames   -- get names of problem's variables
-connames   -- get names of problem's constraints
-objcons    -- objective and constraints
-obj        -- objective and objective gradient
-cons       -- constraints and constraints gradients/Jacobian
-lagjac     -- gradient of objective/Lagrangian and constraints Jacobian
-jprod      -- product of constraints Jacobian with a vector
-hess       -- Hessian of objective/Lagrangian
-ihess      -- Hessian of objective/constraint
-hprod      -- product of Hessian of objective/Lagrangian with a vector
-gradhess   -- gradient and Hessian of objective (unconstrained problems) or
-              gradient of objective/Lagrangian, Jacobian of constraints and
-              Hessian of Lagrangian (constrained problems)
-scons      -- constraints and sparse Jacobian of constraints
-slagjac    -- gradient of objective/Lagrangian and sparse Jacobian
-sphess     -- sparse Hessian of objective/Lagrangian
-isphess    -- sparse Hessian of objective/constraint
-gradsphess -- gradient and sparse Hessian of objective (unconstrained probl.)
-              or gradient of objective/Lagrangian, sparse Jacobian of
-              constraints and sparse Hessian of Lagrangian (constrained probl.)
-report     -- get usage statistics
-terminate  -- clear problem memory
+Available interface functions (those starting with an underscore should be wrapped)
+setup       -- setup problem and get problem information
+_dims       -- get problem dimensions
+_varnames   -- get names of problem's variables
+_connames   -- get names of problem's constraints
+objcons     -- objective and constraints
+obj         -- objective and objective gradient
+cons        -- constraints and constraints gradients/Jacobian
+lagjac      -- gradient of objective/Lagrangian and constraints Jacobian
+jprod       -- product of constraints Jacobian with a vector
+hess        -- Hessian of objective/Lagrangian
+ihess       -- Hessian of objective/constraint
+hprod       -- product of Hessian of objective/Lagrangian with a vector
+gradhess    -- gradient and Hessian of objective (unconstrained problems) or
+               gradient of objective/Lagrangian, Jacobian of constraints and
+               Hessian of Lagrangian (constrained problems)
+_scons      -- constraints and sparse Jacobian of constraints
+_slagjac    -- gradient of objective/Lagrangian and sparse Jacobian
+_sphess     -- sparse Hessian of objective/Lagrangian
+_isphess    -- sparse Hessian of objective/constraint
+_gradsphess -- gradient and sparse Hessian of objective (unconstrained probl.)
+               or gradient of objective/Lagrangian, sparse Jacobian of
+               constraints and sparse Hessian of Lagrangian (constrained probl.)
+report      -- get usage statistics
+terminate   -- clear problem memory
 \"\"\"
 
 # Ensure compatibility with Python 2
@@ -49,259 +50,56 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from ._pycutestitf import *
 from . import _pycutestitf
 import os
-from scipy.sparse import coo_matrix
-from numpy import zeros
 
-# Get the directory where the binary module (and OUTSDIF.d) are found.
-(_directory, _module)=os.path.split(_pycutestitf.__file__)
-
-# Problem info structure and dimension
-info=None
-n=None
-m=None
-
-# Constraints and variable ordering
-efirst=[efirst]
-lfirst=[lfirst]
-nvfirst=[nvfirst]
-
-# Remember current directory and go to module directory where OUTSDIF.d is located
-fromDir=os.getcwd()
-os.chdir(_directory)
-
-# Get problem dimension
-(n, m)=_pycutestitf._dims()
-
-# Set up the problem and get basic information
-info=_pycutestitf._setup(efirst, lfirst, nvfirst)
-
-# Store constraint and variable ordering information
-if m>0:
-    info['efirst']=efirst
-    info['lfirst']=lfirst
-info['nvfirst']=nvfirst
-
-# Store sifdecode parameters and options
-info['sifparams']=[sifParams]
-info['sifoptions']=[sifOptions]
-
-# Go back to initial directory
-os.chdir(fromDir)
-
-# Return problem info
-def getinfo():
+def setup():
     \"\"\"
-    Return the problem info dictionary.
+    Set up the problem and get problem information.
 
-    info=geinfo()
+    info=setup()
 
-    Output
-    info -- dictionary with the summary of test function's properties
-
-    The dictionary has the following members:
-    name       -- problem name
-    n          -- number of variables
-    m          -- number of constraints (excluding bounds)
-    x          -- initial point (1D array of length n)
-    bl         -- 1D array of length n with lower bounds on variables
-    bu         -- 1D array of length n with upper bounds on variables
-    nnzh       -- number of nonzero elements in the diagonal and upper triangle of
-                  sparse Hessian
-    vartype    -- 1D integer array of length n storing variable type
-                  0=real,  1=boolean (0 or 1), 2=integer
-    nvfirst    -- boolean flag indicating that nonlinear variables were placed
-                  before linear variables
-    sifparams  -- parameters passed to sifdecode with the -param option
-                  None if no parameters were given
-    sifoptions -- additional options passed to sifdecode
-                  None if no additional options were given.
-
-    For constrained problems the following additional members are available
-    nnzj    -- number of nonzero elements in sparse Jacobian of constraints
-    v       -- 1D array of length m with initial values of Lagrange multipliers
-    cl      -- 1D array of length m with lower bounds on constraint functions
-    cu      -- 1D array of length m with upper bounds on constraint functions
-    equatn  -- 1D boolean array of length m indicating whether a constraint
-               is an equation constraint
-    linear  -- 1D boolean array of length m indicating whether a constraint
-               is a linear constraint
-    efirst  -- boolean flag indicating that equation constraints were places
-               before inequation constraints
-    lfirst  -- boolean flag indicating that linear constraints were placed
-               before nonlinear constraints
+    info -- dictionary with the summary of test function's properties (see getinfo())
     \"\"\"
+
+    # Get the directory where the binary module (and OUTSDIF.d) are found.
+    (_directory, _module)=os.path.split(_pycutestitf.__file__)
+
+    # Problem info structure and dimension
+    info=None
+    n=None
+    m=None
+
+    # Constraints and variable ordering
+    efirst=[efirst]
+    lfirst=[lfirst]
+    nvfirst=[nvfirst]
+
+    # Remember current directory and go to module directory where OUTSDIF.d is located
+    fromDir=os.getcwd()
+    os.chdir(_directory)
+
+    # Get problem dimension
+    (n, m)=_pycutestitf._dims()
+
+    # Set up the problem and get basic information
+    info=_pycutestitf._setup(efirst, lfirst, nvfirst)
+
+    # Store constraint and variable ordering information
+    if m>0:
+        info['efirst']=efirst
+        info['lfirst']=lfirst
+    info['nvfirst']=nvfirst
+
+    # Store sifdecode parameters and options
+    info['sifparams']=[sifParams]
+    info['sifoptions']=[sifOptions]
+
+    # Go back to initial directory
+    os.chdir(fromDir)
+
     return info
 
-def varnames():
-    \"\"\"
-    Return the names of problem's variables.
-
-    nameList=varnames()
-
-    nameList -- a list of strings representing the names of problem's variables.
-                The variabels are ordered according to nvfirst flag.
-    \"\"\"
-    return _pycutestitf._varnames()
-
-def connames():
-    \"\"\"
-    Return the names of problem's constraints.
-
-    nameList=connames()
-
-    nameList -- a list of strings representing the names of problem constraints.
-                The constraints are ordered according to efirst and lfirst flags.
-    \"\"\"
-    return _pycutestitf._connames()
-
-# Sparse tool wrappers (return scipy.sparse.coo_matrix matrices)
-# _scons() wrapper
-def scons(x, i=None):
-    \"\"\"Returns the value of constraints and
-    the sparse Jacobian of constraints at x.
-
-    (c, J)=_scons(x)      -- Jacobian of constraints
-    (ci, gi)=_scons(x, i) -- i-th constraint and its gradient
-
-    Input
-    x -- 1D array of length n with the values of variables
-    i -- integer index of constraint (between 0 and m-1)
-
-    Output
-    c  -- 1D array of length m holding the values of constraints at x
-    J  -- a scipy.sparse.coo_matrix of size m-by-n holding the Jacobian at x
-    ci -- 1D array of length 1 holding the value of i-th constraint at x
-    gi -- a scipy.sparse.coo_matrix of size 1-by-n holding the gradient of i-th constraint at x
-
-    This function is a wrapper for _scons().
-    \"\"\"
-
-    if i is None:
-        (c, Ji, Jif, Jv)=_pycutestitf._scons(x)
-        return (c, coo_matrix((Jv, (Jif, Ji)), shape=(m, n)))
-    else:
-        (c, gi, gv)=_pycutestitf._scons(x, i)
-        return (c, coo_matrix((gv, (zeros(len(gv)), gi)), shape=(1, n)))
-
-# _slagjac() wrapper
-def slagjac(x, v=None):
-    \"\"\"Returns the sparse gradient of objective at x or Lagrangian at (x, v),
-    and the sparse Jacobian of constraints at x.
-
-    (g, J)=_slagjac(x)    -- objective gradient and Jacobian
-    (g, J)=_slagjac(x, v) -- Lagrangian gradient and Jacobian
-
-    Input
-    x -- 1D array of length n with the values of variables
-    v -- 1D array of length m with the values of Lagrange multipliers
-
-    Output
-    g -- a scipy.sparse.coo_matrix of size 1-by-n holding the gradient of objective at x or
-         the gradient of Lagrangian at (x, v)
-    J -- a scipy.sparse.coo_matrix of size m-by-n holding the sparse Jacobian
-         of constraints at x
-
-    This function is a wrapper for _slagjac().
-    \"\"\"
-
-    if v is None:
-        (gi, gv, Ji, Jfi, Jv)=_pycutestitf._slagjac(x)
-    else:
-        (gi, gv, Ji, Jfi, Jv)=_pycutestitf._slagjac(x, v)
-    return (
-        coo_matrix((gv, (zeros(len(gv)), gi)), shape=(1, n)),
-        coo_matrix((Jv, (Jfi, Ji)), shape=(m, n))
-    )
-
-# _sphess() wrapper
-def sphess(x, v=None):
-    \"\"\"Returns the sparse Hessian of the objective at x (unconstrained problems)
-    or the sparse Hessian of the Lagrangian (constrained problems) at (x, v).
-
-    H=_sphess(x)    -- Hessian of objective (unconstrained problems)
-    H=_sphess(x, v) -- Hessian of Lagrangian (constrained problems)
-
-    Input
-    x -- 1D array of length n with the values of variables
-    v -- 1D array of length m with the values of Lagrange multipliers
-
-    Output
-    H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
-         of objective at x or the sparse Hessian of the Lagrangian at (x, v)
-
-    This function is a wrapper for _sphess().
-    \"\"\"
-
-    if v is None:
-        (Hi, Hj, Hv)=_pycutestitf._sphess(x)
-    else:
-        (Hi, Hj, Hv)=_pycutestitf._sphess(x, v)
-    return coo_matrix((Hv, (Hi, Hj)), shape=(n, n))
-
-# _isphess() wrapper
-def isphess(x, i=None):
-    \"\"\"Returns the sparse Hessian of the objective or the sparse Hessian of i-th
-    constraint at x.
-
-    H=_isphess(x)    -- Hessian of objective
-    H=_isphess(x, i) -- Hessian of i-th constraint
-
-    Input
-    x -- 1D array of length n with the values of variables
-    i -- integer holding the index of constraint (between 0 and m-1)
-
-    Output
-    H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
-         of objective or the sparse Hessian i-th constraint at x
-
-    This function is a wrapper for _isphess().
-    \"\"\"
-
-    if i is None:
-        (Hi, Hj, Hv)=_pycutestitf._isphess(x)
-    else:
-        (Hi, Hj, Hv)=_pycutestitf._isphess(x, i)
-    return coo_matrix((Hv, (Hi, Hj)), shape=(n, n))
-
-# _gradsphess() wrapper
-def gradsphess(x, v=None, lagrFlag=False):
-    \"\"\"Returns the sparse Hessian of the Lagrangian, the sparse Jacobian of
-    constraints, and the gradient of the objective or Lagrangian.
-
-    (g, H)=gradsphess(x)              -- unconstrained problems
-    (g, J, H)=gradsphess(x, v, gradl) -- constrained problems
-
-    Input
-    x     -- 1D array of length n with the values of variables
-    v     -- 1D array of length m with the values of Lagrange multipliers
-    gradl -- boolean flag. If False the gradient of the objective is returned,
-             if True the gradient of the Lagrangian is returned.
-             Default is False
-
-    Output
-    g -- a scipy.sparse.coo_matrix of size 1-by-n holding the gradient of objective at x or
-         the gradient of Lagrangian at (x, v)
-    J -- a scipy.sparse.coo_matrix of size m-by-n holding the sparse Jacobian
-         of constraints at x
-    H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
-         of objective at x or the sparse Hessian of the Lagrangian at (x, v)
-
-    This function is a wrapper for _gradsphess().
-    \"\"\"
-
-    if v is None:
-        (g, Hi, Hj, Hv)=_pycutestitf._gradsphess(x)
-        return (coo_matrix(g), coo_matrix((Hv, (Hi, Hj)), shape=(n, n)))
-    else:
-        (gi, gv, Ji, Jfi, Jv, Hi, Hj, Hv)=_pycutestitf._gradsphess(x, v, lagrFlag)
-        return (
-            coo_matrix((gv, (zeros(len(gv)), gi)), shape=(1, n)),
-            coo_matrix((Jv, (Jfi, Ji)), shape=(m, n)),
-            coo_matrix((Hv, (Hi, Hj)), shape=(n, n))
-        )
-
 # Clean up
-del os, fromDir, efirst, lfirst, nvfirst
+del os
 """
 
 

--- a/pycutest/python_interface.py
+++ b/pycutest/python_interface.py
@@ -49,7 +49,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from ._pycutestitf import *
 from . import _pycutestitf
-import os
 
 def setup():
     \"\"\"
@@ -59,6 +58,7 @@ def setup():
 
     info -- dictionary with the summary of test function's properties (see getinfo())
     \"\"\"
+    import os
 
     # Get the directory where the binary module (and OUTSDIF.d) are found.
     (_directory, _module)=os.path.split(_pycutestitf.__file__)
@@ -98,8 +98,6 @@ def setup():
 
     return info
 
-# Clean up
-del os
 """
 
 

--- a/pycutest/python_interface.py
+++ b/pycutest/python_interface.py
@@ -40,6 +40,7 @@ gradsphess -- gradient and sparse Hessian of objective (unconstrained probl.)
               or gradient of objective/Lagrangian, sparse Jacobian of
               constraints and sparse Hessian of Lagrangian (constrained probl.)
 report     -- get usage statistics
+terminate  -- clear problem memory
 \"\"\"
 
 # Ensure compatibility with Python 2


### PR DESCRIPTION
Fix memory leak reported in #42 due to not calling `CUTEST_uterminate` or `CUTEST_cterminate`.

This fix adds the [`__del__` finaliser](https://docs.python.org/3/reference/datamodel.html#object.__del__) to the `CUTEstProblem` class and uses it to call `CUTEST_uterminate` or `CUTEST_cterminate` (as appropriate) via the C interface whenever a `CUTEstProblem` class instance is garbage collected.

I have tested this fix and valgrind no longer detects any memory leaks in CUTEst itself.

Resolves #42
 