### PR TITLE
Use homebrew prefix for fallback paths on macOS

### DIFF
--- a/pycutest/system_paths.py
+++ b/pycutest/system_paths.py
@@ -12,6 +12,10 @@ __all__ = ['check_platform', 'get_cutest_path', 'get_sifdecoder_path', 'get_mast
 
 base_dir = os.getcwd()
 
+if sys.platform == 'darwin':  # Mac
+    import subprocess
+    homebrew_prefix = subprocess.check_output(['brew', '--prefix']).decode('utf-8')[:-1]
+
 def check_platform():
     if sys.platform not in ['linux', 'linux2', 'darwin']:
         raise ImportError("Unsupported platform: " + sys.platform)
@@ -33,7 +37,7 @@ def get_cutest_path():
             cutest_path = os.path.join(os.environ['CUTEST'], 'objects', os.environ['MYARCH'], 'double', 'libcutest.a')
             if os.path.isfile(cutest_path):
                 return cutest_path
-        homebrew_path = os.path.join('usr', 'local', 'opt', 'cutest', 'lib', 'libcutest.a')  # /usr/local/opt/cutest/lib/libcutest.a
+        homebrew_path = os.path.join(homebrew_prefix, 'opt', 'cutest', 'lib', 'libcutest.a')  # /usr/local/opt/cutest/lib/libcutest.a
         if os.path.isfile(homebrew_path):
             return homebrew_path
         else:
@@ -54,7 +58,7 @@ def get_sifdecoder_path():
             sifdecoder_path = os.path.join(os.environ['SIFDECODE'], 'bin', 'sifdecoder')
             if os.path.isfile(sifdecoder_path):
                 return sifdecoder_path
-        homebrew_path = os.path.join('usr', 'local', 'opt', 'sifdecode', 'bin', 'sifdecoder')  # /usr/local/opt/sifdecode/bin/sifdecoder
+        homebrew_path = os.path.join(homebrew_prefix, 'opt', 'sifdecode', 'bin', 'sifdecoder')  # /usr/local/opt/sifdecode/bin/sifdecoder
         if os.path.isfile(homebrew_path):
             return homebrew_path
         else:
@@ -75,7 +79,7 @@ def get_mastsif_path():
             mastsif_path = os.environ['MASTSIF']
             if os.path.isdir(mastsif_path):
                 return mastsif_path
-        homebrew_path = os.path.join('usr', 'local', 'opt', 'mastsif', 'share', 'mastsif')  # /usr/local/opt/mastsif/share/mastsif
+        homebrew_path = os.path.join(homebrew_prefix, 'opt', 'mastsif', 'share', 'mastsif')  # /usr/local/opt/mastsif/share/mastsif
         if os.path.isdir(homebrew_path):
             return homebrew_path
         else:

--- a/pycutest/system_paths.py
+++ b/pycutest/system_paths.py
@@ -12,6 +12,7 @@ __all__ = ['check_platform', 'get_cutest_path', 'get_sifdecoder_path', 'get_mast
 
 base_dir = os.getcwd()
 
+homebrew_prefix = None
 if sys.platform == 'darwin':  # Mac
     import subprocess
     homebrew_prefix = subprocess.check_output(['brew', '--prefix']).decode('utf-8')[:-1]

--- a/pycutest/system_paths.py
+++ b/pycutest/system_paths.py
@@ -37,7 +37,7 @@ def get_cutest_path():
             cutest_path = os.path.join(os.environ['CUTEST'], 'objects', os.environ['MYARCH'], 'double', 'libcutest.a')
             if os.path.isfile(cutest_path):
                 return cutest_path
-        homebrew_path = os.path.join(homebrew_prefix, 'opt', 'cutest', 'lib', 'libcutest.a')  # /usr/local/opt/cutest/lib/libcutest.a
+        homebrew_path = os.path.join(homebrew_prefix, 'opt', 'cutest', 'lib', 'libcutest.a')  # HOMEBREW_PREFIX/opt/cutest/lib/libcutest.a
         if os.path.isfile(homebrew_path):
             return homebrew_path
         else:
@@ -58,7 +58,7 @@ def get_sifdecoder_path():
             sifdecoder_path = os.path.join(os.environ['SIFDECODE'], 'bin', 'sifdecoder')
             if os.path.isfile(sifdecoder_path):
                 return sifdecoder_path
-        homebrew_path = os.path.join(homebrew_prefix, 'opt', 'sifdecode', 'bin', 'sifdecoder')  # /usr/local/opt/sifdecode/bin/sifdecoder
+        homebrew_path = os.path.join(homebrew_prefix, 'opt', 'sifdecode', 'bin', 'sifdecoder')  # HOMEBREW_PREFIX/opt/sifdecode/bin/sifdecoder
         if os.path.isfile(homebrew_path):
             return homebrew_path
         else:
@@ -79,7 +79,7 @@ def get_mastsif_path():
             mastsif_path = os.environ['MASTSIF']
             if os.path.isdir(mastsif_path):
                 return mastsif_path
-        homebrew_path = os.path.join(homebrew_prefix, 'opt', 'mastsif', 'share', 'mastsif')  # /usr/local/opt/mastsif/share/mastsif
+        homebrew_path = os.path.join(homebrew_prefix, 'opt', 'mastsif', 'share', 'mastsif')  # HOMEBREW_PREFIX/opt/mastsif/share/mastsif
         if os.path.isdir(homebrew_path):
             return homebrew_path
         else:


### PR DESCRIPTION
The fallback paths on macOS should not be hardcoded with `/usr/local/` as this will break on the new ARM macs since they do not use `/usr/local/` by default (c.f. #39).

This PR switches to querying homebrew for its install location in the same way as #39 does in `install_scripts.py` (this still returns `/usr/local/` on my Intel mac install). 

This also resolves #45 
