### PR TITLE
Restore current working directory on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,4 @@ jobs:
         python -m unittest pycutest.tests.test_sparse_functionality
         python -m unittest pycutest.tests.test_sifparam_chars
         python -m unittest pycutest.tests.test_multiple_instances
+        python -m unittest pycutest.tests.test_restore_cwd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
       run: |
         source ./.cutest.env
         export PYCUTEST_CACHE="$GITHUB_WORKSPACE/pycutest_cache"
+        export TERM=xterm
         python -m unittest pycutest.tests.test_sifdecode_extras
         python -m unittest pycutest.tests.test_basic_functionality
         python -m unittest pycutest.tests.test_sparse_functionality

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -41,6 +41,7 @@ jobs:
         source /usr/local/opt/cutest/cutest.bashrc
         export PYCUTEST_CACHE="$GITHUB_WORKSPACE/pycutest_cache"
         export MACOSX_DEPLOYMENT_TARGET=12.5
+        export TERM=xterm
         python -m unittest pycutest.tests.test_sifdecode_extras
         python -m unittest pycutest.tests.test_basic_functionality
         python -m unittest pycutest.tests.test_sparse_functionality

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -46,3 +46,4 @@ jobs:
         python -m unittest pycutest.tests.test_sparse_functionality
         python -m unittest pycutest.tests.test_sifparam_chars
         python -m unittest pycutest.tests.test_multiple_instances
+        python -m unittest pycutest.tests.test_restore_cwd

--- a/pycutest/tests/problems/SCURLY20.SIF
+++ b/pycutest/tests/problems/SCURLY20.SIF
@@ -1,0 +1,125 @@
+***************************
+* SET UP THE INITIAL DATA *
+***************************
+
+NAME          SCURLY20
+
+*   Problem :
+*   --------
+
+*   A banded function with semi-bandwidth 10 and
+*   negative curvature near the starting point.
+*   NB: scaled version of CURLY20
+
+*   Source: Nick Gould
+
+*   SIF input: Nick Gould, September 1997.
+
+*   classification OUR2-AN-V-0
+
+*   Number of variables
+
+*IE N                   10             $-PARAMETER
+*IE N                   100            $-PARAMETER
+*IE N                   1000           $-PARAMETER     original value
+ IE N                   10000          $-PARAMETER
+*IE N                   100000         $-PARAMETER
+*IE N                   1000000        $-PARAMETER
+
+*  Semi-bandwidth
+
+ IE K                   20
+
+*  ratio of smallest to largest scale factors will be exp(scal)
+
+ RE SCAL                12.0
+
+*   other parameter definitions
+
+ IE 1                   1
+ I- N-K       N                        K
+ IA N-K+1     N-K       1
+ RI RN        N
+ RA RN-1      RN        -1
+ RA RN+1      RN        1
+
+VARIABLES
+
+ DO I         1                        N
+ IA I-1       I         -1
+ RI RI-1      I-1
+ R/ RAT       RI-1                     RN-1
+ R* ARG       RAT                      SCAL
+ A( S(I)      EXP                      ARG
+ Z  X(I)
+ ND
+
+GROUPS
+
+ DO I         1                        N-K
+ I+ I+K       I                        K
+ DO J         I                        I+K
+ ZN Q(I)      X(J)                     S(J)
+ ND
+
+ DO I         N-K+1                    N
+ DO J         I                        N
+ ZN Q(I)      X(J)                     S(J)
+ ND
+
+BOUNDS
+
+ FR SCURLY20  'DEFAULT'
+
+START POINT
+
+*  start with X(I) = 0.0001 * I * S(I) / (N+1).
+
+ DO I         1                        N
+
+ RI RI        I
+ R/ T         RI                       RN+1
+ RM T         T         0.0001
+ A* T         T                        S(I)
+ ZV SCURLY20  X(I)                     T
+
+ ND
+
+GROUP TYPE
+
+ GV P4        GVAR
+
+GROUP USES
+
+ XT 'DEFAULT' P4
+
+OBJECT BOUND
+
+*   Solution
+
+*ZL SOLTN               -1.003162D+5   $ (n=1000)
+
+ENDATA
+
+*********************
+* SET UP THE GROUPS *
+* ROUTINE           *
+*********************
+
+GROUPS        SCURLY20
+
+TEMPORARIES
+
+ R  APB
+
+INDIVIDUALS
+
+ T  P4
+ A  APB                 2.0D+1
+ F                      GVAR * ( GVAR * ( GVAR ** 2 - APB )
+ F+                     - 1.0D-1 )
+ G                      2.0D+0 * GVAR * ( 2.0D+0 * GVAR ** 2
+ G+                     - APB ) - 1.0D-1
+ H                      1.2D+1 * GVAR ** 2 - 2.0D+0 * APB
+
+ENDATA

--- a/pycutest/tests/test_restore_cwd.py
+++ b/pycutest/tests/test_restore_cwd.py
@@ -1,0 +1,19 @@
+import os
+import pycutest
+import unittest
+
+# All problems used here: SCURLY20
+
+class testCUTEstRestoreCWD(unittest.TestCase):
+    def runTest(self):
+        # clear cached problems (if any)
+        pycutest.clear_cache('SCURLY20', sifParams={'N':10})
+
+        # test restoration of current working directory on problem failure
+        try:
+            print("Testing problem failure...")
+            pycutest.import_problem('SCURLY20', sifParams={'N': 10})
+        except RuntimeError:
+            print("Problem failed as expected, testing restoration of cwd...")
+        print(os.getcwd())
+        print()

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 envlist =
-    py36
-    py37
     py38
     py39
     py310
+    py311
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Resolves #54 

We were rather sloppy in our directory handling and were not restoring the current working directory on errors when building various parts of the interface. This PR simply restores the current working directory before raising errors.

I have also taken the opportunity to remove some ancient Python 2 stuff from `build_interface` as we are now Python 3 only, namely unicode (which was renamed to str) and the FileNotFoundError definition.

To test, use the minimal working example from #54 
```python
import os, pycutest

try:
    prob = pycutest.import_problem('SCURLY20', sifParams={'N': 10})
except RuntimeError:
    print("Loading failed.")
print(os.getcwd())
```
this should now pass as expected (at least it does for me).