### PR TITLE
Fix invalid sparse Hessian dimensions while dropping fixed variables

### DIFF
--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -758,7 +758,7 @@ class CUTEstProblem(object):
         v -- 1D array of length m with the values of Lagrange multipliers
 
         Output
-        H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
+        H -- a scipy.sparse.coo_matrix of size n_full-by-n_full holding the sparse Hessian
             of objective at x or the sparse Hessian of the Lagrangian at (x, v)
 
         This function is a wrapper for sphess().
@@ -768,7 +768,7 @@ class CUTEstProblem(object):
             (Hi, Hj, Hv)=self._module.sphess(x)
         else:
             (Hi, Hj, Hv)=self._module.sphess(x, v)
-        return coo_matrix((Hv, (Hi, Hj)), shape=(self.n, self.n))
+        return coo_matrix((Hv, (Hi, Hj)), shape=(self.n_full, self.n_full))
 
     def sphess(self, x, v=None):
         """

--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -612,19 +612,19 @@ class CUTEstProblem(object):
 
         Output
         c  -- 1D array of length m holding the values of constraints at x
-        J  -- a scipy.sparse.coo_matrix of size m-by-n holding the Jacobian at x
+        J  -- a scipy.sparse.coo_matrix of size m-by-n_full holding the Jacobian at x
         ci -- 1D array of length 1 holding the value of i-th constraint at x
-        gi -- a scipy.sparse.coo_matrix of size 1-by-n holding the gradient of i-th constraint at x
+        gi -- a scipy.sparse.coo_matrix of size 1-by-n_full holding the gradient of i-th constraint at x
 
         This function is a wrapper for scons().
         """
 
         if i is None:
             (c, Ji, Jif, Jv)=self._module.scons(x)
-            return (c, coo_matrix((Jv, (Jif, Ji)), shape=(self.m, self.n)))
+            return (c, coo_matrix((Jv, (Jif, Ji)), shape=(self.m, self.n_full)))
         else:
             (c, gi, gv)=self._module.scons(x, i)
-            return (c, coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n)))
+            return (c, coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n_full)))
 
     def scons(self, x, index=None, gradient=False):
         """
@@ -689,9 +689,9 @@ class CUTEstProblem(object):
         v -- 1D array of length m with the values of Lagrange multipliers
 
         Output
-        g -- a scipy.sparse.coo_matrix of size 1-by-n holding the gradient of objective at x or
+        g -- a scipy.sparse.coo_matrix of size 1-by-n_full holding the gradient of objective at x or
             the gradient of Lagrangian at (x, v)
-        J -- a scipy.sparse.coo_matrix of size m-by-n holding the sparse Jacobian
+        J -- a scipy.sparse.coo_matrix of size m-by-n_full holding the sparse Jacobian
             of constraints at x
 
         This function is a wrapper for slagjac().
@@ -702,8 +702,8 @@ class CUTEstProblem(object):
         else:
             (gi, gv, Ji, Jfi, Jv)=self._module.slagjac(x, v)
         return (
-            coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n)),
-            coo_matrix((Jv, (Jfi, Ji)), shape=(self.m, self.n))
+            coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n_full)),
+            coo_matrix((Jv, (Jfi, Ji)), shape=(self.m, self.n_full))
         )
 
     def slagjac(self, x, v=None):
@@ -824,7 +824,7 @@ class CUTEstProblem(object):
         i -- integer holding the index of constraint (between 0 and m-1)
 
         Output
-        H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
+        H -- a scipy.sparse.coo_matrix of size n_full-by-n_full holding the sparse Hessian
             of objective or the sparse Hessian i-th constraint at x
 
         This function is a wrapper for isphess().
@@ -834,7 +834,7 @@ class CUTEstProblem(object):
             (Hi, Hj, Hv)=self._module.isphess(x)
         else:
             (Hi, Hj, Hv)=self._module.isphess(x, i)
-        return coo_matrix((Hv, (Hi, Hj)), shape=(self.n, self.n))
+        return coo_matrix((Hv, (Hi, Hj)), shape=(self.n_full, self.n_full))
 
     def isphess(self, x, cons_index=None):
         """
@@ -885,11 +885,11 @@ class CUTEstProblem(object):
                 Default is False
 
         Output
-        g -- a scipy.sparse.coo_matrix of size 1-by-n holding the gradient of objective at x or
+        g -- a scipy.sparse.coo_matrix of size 1-by-n_full holding the gradient of objective at x or
             the gradient of Lagrangian at (x, v)
-        J -- a scipy.sparse.coo_matrix of size m-by-n holding the sparse Jacobian
+        J -- a scipy.sparse.coo_matrix of size m-by-n_full holding the sparse Jacobian
             of constraints at x
-        H -- a scipy.sparse.coo_matrix of size n-by-n holding the sparse Hessian
+        H -- a scipy.sparse.coo_matrix of size n_full-by-n_full holding the sparse Hessian
             of objective at x or the sparse Hessian of the Lagrangian at (x, v)
 
         This function is a wrapper for gradsphess().
@@ -897,13 +897,13 @@ class CUTEstProblem(object):
 
         if v is None:
             (g, Hi, Hj, Hv)=self._module.gradsphess(x)
-            return (coo_matrix(g), coo_matrix((Hv, (Hi, Hj)), shape=(self.n, self.n)))
+            return (coo_matrix(g), coo_matrix((Hv, (Hi, Hj)), shape=(self.n_full, self.n_full)))
         else:
             (gi, gv, Ji, Jfi, Jv, Hi, Hj, Hv)=self._module.gradsphess(x, v, lagrFlag)
             return (
-                coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n)),
-                coo_matrix((Jv, (Jfi, Ji)), shape=(self.m, self.n)),
-                coo_matrix((Hv, (Hi, Hj)), shape=(self.n, self.n))
+                coo_matrix((gv, (np.zeros(len(gv)), gi)), shape=(1, self.n_full)),
+                coo_matrix((Jv, (Jfi, Ji)), shape=(self.m, self.n_full)),
+                coo_matrix((Hv, (Hi, Hj)), shape=(self.n_full, self.n_full))
             )
 
     def gradsphess(self, x, v=None, gradient_of_lagrangian=True):

--- a/pycutest/tests/problems/BOX2.SIF
+++ b/pycutest/tests/problems/BOX2.SIF
@@ -1,0 +1,149 @@
+***************************
+* SET UP THE INITIAL DATA *
+***************************
+
+NAME          BOX2
+
+*   Problem :
+*   *********
+*   Box problem in 2 variables, obtained by fixing X3 = 1 in BOX3.
+
+*   Source: Problem 11 in
+*   A.R. Buckley,
+*   "Test functions for unconstrained minimization",
+*   TR 1989CS-3, Mathematics, statistics and computing centre,
+*   Dalhousie University, Halifax (CDN), 1989.
+
+*   SIF input: Ph. Toint, Dec 1989.
+
+*   classification SXR2-AN-3-0
+
+*   This function  is a nonlinear least squares with 10 groups.  Each
+*   group has 2 nonlinear elements of exponential type.
+
+*   Number of groups
+
+ IE M                   10
+
+*   Useful parameters
+
+ IE 1                   1
+
+VARIABLES
+
+    X1
+    X2
+    X3
+
+GROUPS
+
+ DO I         1                        M
+
+ RI RI        I
+ RM MRI       RI        -1.0
+ RM MTI       RI        -0.1
+ R( EMTI      EXP                      MTI
+ R( EMRI      EXP                      MRI
+ RM MEMTI     EMTI      -1.0
+ R+ COEFF     MEMTI                    EMRI
+
+ ZN G(I)      X3                       COEFF
+
+ ND
+
+BOUNDS
+
+ FR BOX2      'DEFAULT'
+ FX BOX2      X3        1.0
+
+START POINT
+
+    BOX2      X1        0.0
+    BOX2      X2        10.0
+    BOX2      X3        1.0
+
+ELEMENT TYPE
+
+ EV EXPT      V
+ EP EXPT      T
+
+ELEMENT USES
+
+ XT 'DEFAULT' EXPT
+
+ DO I         1                        M
+
+ RI RI        I
+ RM MTI       RI        -0.1
+
+ ZV A(I)      V                        X1
+ ZP A(I)      T                        MTI
+
+ ZV B(I)      V                        X2
+ ZP B(I)      T                        MTI
+
+ ND
+
+GROUP TYPE
+
+ GV L2        GVAR
+
+GROUP USES
+
+ XT 'DEFAULT' L2
+
+ DO I         1                        M
+ XE G(I)      A(I)      1.0            B(I)      -1.0
+ ND
+
+OBJECT BOUND
+
+ LO BOX2                0.0
+
+*   Solution
+
+*LO SOLTN               0.0
+
+ENDATA
+
+***********************
+* SET UP THE FUNCTION *
+* AND RANGE ROUTINES  *
+***********************
+
+ELEMENTS      BOX2
+
+TEMPORARIES
+
+ M  EXP
+ R  EXPA
+
+INDIVIDUALS
+
+*   Exponential
+
+ T  EXPT
+ A  EXPA                EXP( T * V )
+ F                      EXPA
+ G  V                   T * EXPA
+ H  V         V         T * T * EXPA
+
+ENDATA
+
+*********************
+* SET UP THE GROUPS *
+* ROUTINE           *
+*********************
+
+GROUPS        BOX2
+
+INDIVIDUALS
+
+*   Least-square groups
+
+ T  L2
+ F                      GVAR * GVAR
+ G                      GVAR + GVAR
+ H                      2.0
+
+ENDATA

--- a/pycutest/tests/problems/ZIGZAG.SIF
+++ b/pycutest/tests/problems/ZIGZAG.SIF
@@ -1,0 +1,241 @@
+***************************
+* SET UP THE INITIAL DATA *
+***************************
+
+NAME          ZIGZAG
+
+*   Problem :
+*   *********
+
+*   A nonlinear optimal control problem with both state- and
+*   control constraints.
+*   The problem is to control (using an applied force of limited
+*   magnitude) a mass moving in the plane, such that its
+*   trajectory lies within a prescribed distance TOL of the curve y=sin(x),
+*   and such that it stops at a given abscissa XT in minimum time.
+*   The mass is initially stationary at the origin.
+
+*   Source:
+*   Ph. Toint, private communication.
+
+*   SIF input: Ph. Toint, April 1991.
+
+*   classification SOR2-AN-V-V
+
+*   Number of time intervals
+*   The number of variables is 6T+4, of which 6 are fixed.
+
+*IE T                   10             $-PARAMETER n = 64   original value
+*IE T                   50             $-PARAMETER n = 304
+*IE T                   100            $-PARAMETER n = 604
+ IE T                   500            $-PARAMETER n = 3004
+
+*   Target abscissa
+
+ RE XT                  10.0
+
+*   Mass
+
+ RE MASS                0.5
+
+*   Tolerance along the sine trajectory
+
+ RE TOL                 0.1
+
+*   Constants
+
+ IE 0                   0
+ IE 1                   1
+
+*   Useful parameters
+
+ RI RT        T
+ RA T+1       RT        1.0
+ R/ H         XT                       RT
+ RD 1/H       H         1.0
+ RM -1/H      1/H       -1.0
+ R/ M/H       MASS                     H
+ RM -M/H      M/H       -1.0
+ RM -TOL      TOL       -1.0
+ RM 2TOL      TOL       2.0
+ R* XTT+1     XT                       T+1
+ RM W         XTT+1     0.5
+ DO I         1                        T
+ RI RI        I
+ R* TI        RI                       H
+ A/ W/T(I)    W                        TI
+ ND
+
+*   Maximal force at any time
+
+ R/ FMAX      XT                       RT
+ RM -FMAX     FMAX      -1.0
+
+VARIABLES
+
+ DO I         0                        T
+ X  X(I)
+ X  Y(I)
+ X  VX(I)
+ X  VY(I)
+ ND
+
+ DO I         1                        T
+ X  UX(I)
+ X  UY(I)
+ ND
+
+GROUPS
+
+ DO I         1                        T
+ ZN OX(I)     'SCALE'                  W/T(I)
+ XN OX(I)     X(I)      1.0
+ ND
+
+ DO I         1                        T
+ IA I-1       I         -1
+
+ ZE ACX(I)    VX(I)                    M/H
+ ZE ACX(I)    VX(I-1)                  -M/H
+ XE ACX(I)    UX(I)     -1.0
+
+ ZE ACY(I)    VY(I)                    M/H
+ ZE ACY(I)    VY(I-1)                  -M/H
+ XE ACY(I)    UY(I)     -1.0
+
+ ZE PSX(I)    X(I)                     1/H
+ ZE PSX(I)    X(I-1)                   -1/H
+ XE PSX(I)    VX(I)     -1.0
+
+ ZE PSY(I)    Y(I)                     1/H
+ ZE PSY(I)    Y(I-1)                   -1/H
+ XE PSY(I)    VY(I)     -1.0
+
+ XG SC(I)     Y(I)      1.0
+
+ ND
+
+CONSTANTS
+
+ DO I         1                        T
+ Z  ZIGZAG    OX(I)                    XT
+ Z  ZIGZAG    SC(I)                    -TOL
+ ND
+
+RANGES
+
+ DO I         1                        T
+ Z  ZIGZAG    SC(I)                    2TOL
+ ND
+
+BOUNDS
+
+ FR ZIGZAG    'DEFAULT'
+
+ XX ZIGZAG    X(0)      0.0
+ XX ZIGZAG    Y(0)      0.0
+ XX ZIGZAG    VX(0)     0.0
+ XX ZIGZAG    VY(0)     0.0
+
+ XX ZIGZAG    VX(T)     0.0
+ XX ZIGZAG    VY(T)     0.0
+
+ DO I         1                        T
+ ZL ZIGZAG    UX(I)                    -FMAX
+ ZU ZIGZAG    UX(I)                    FMAX
+ ZL ZIGZAG    UY(I)                    -FMAX
+ ZU ZIGZAG    UY(I)                    FMAX
+ XL ZIGZAG    X(I)      0.0
+ ZU ZIGZAG    X(I)                     XT
+ ND
+
+START POINT
+
+ XV ZIGZAG    X(0)      0.0
+ XV ZIGZAG    Y(0)      0.0
+ XV ZIGZAG    VX(0)     0.0
+ XV ZIGZAG    VY(0)     0.0
+
+ XV ZIGZAG    VX(T)     0.0
+ XV ZIGZAG    VY(T)     0.0
+
+ DO I         1                        T
+ RI RI        I
+ R* TI        RI                       H
+ Z  ZIGZAG    X(I)                     TI
+ X  ZIGZAG    VX(I)     1.0
+ ND
+
+ELEMENT TYPE
+
+ EV SINE      X
+
+ELEMENT USES
+
+ DO I         1                        T
+ XT SINX(I)   SINE
+ ZV SINX(I)   X                        X(I)
+ ND
+
+GROUP TYPE
+
+ GV L2        GVAR
+
+GROUP USES
+
+ DO I         1                        T
+ XT OX(I)     L2
+ XE SC(I)     SINX(I)   -1.0
+ ND
+
+OBJECT BOUND
+
+*   Solution
+
+*LO SOLTN(10)           1.79999921
+*LO SOLTN(50)           3.37869476
+*LO SOLTN(100)          5.23053464
+*LO SOLTN(1000)         ???
+
+ENDATA
+
+***********************
+* SET UP THE FUNCTION *
+* AND RANGE ROUTINES  *
+***********************
+
+ELEMENTS      ZIGZAG
+
+TEMPORARIES
+
+ R  SINX
+ M  SIN
+ M  COS
+
+INDIVIDUALS
+
+ T  SINE
+ A  SINX                SIN(X)
+ F                      SIN(X)
+ G  X                   COS(X)
+ H  X         X         - SINX
+
+ENDATA
+
+*********************
+* SET UP THE GROUPS *
+* ROUTINE           *
+*********************
+
+GROUPS        ZIGZAG
+
+*   Least-square groups
+
+INDIVIDUALS
+
+ T  L2
+ F                      GVAR * GVAR
+ G                      GVAR + GVAR
+ H                      2.0
+
+ENDATA

--- a/pycutest/tests/test_sparse_functionality.py
+++ b/pycutest/tests/test_sparse_functionality.py
@@ -2,7 +2,7 @@ import numpy as np
 import pycutest
 import unittest
 
-# All problems used here: ARWHEAD (unconstrained) / ARWHDNE (constrained)
+# All problems used here: ARWHEAD (unconstrained) / ARWHDNE (constrained) / BOX2 (unconstrained fixed variable) / ZIGZAG (constrained fixed variable)
 # Test sparsity by comparing to dense versions
 
 def array_compare(x, y, thresh=1e-8):
@@ -59,13 +59,110 @@ class TestSparseConstrained(unittest.TestCase):
             # scons
             c = p.scons(x)
             self.assertTrue(array_compare(cdense, c, thresh=10**(-places)), msg="scons c is wrong 1")
-            for i in range(p.n):
+            for i in range(p.m):
                 ci = p.scons(x, index=i)
                 self.assertAlmostEqual(ci, cdense[i], places=places, msg="scons ci is wrong 2 [i = %g]" % i)
             c, J = p.scons(x, gradient=True)
             self.assertTrue(array_compare(cdense, c, thresh=10 ** (-places)), msg="scons c is wrong 3")
             self.assertTrue(array_compare(Jdense, J.toarray(), thresh=10 ** (-places)), msg="scons J is wrong 3")
-            for i in range(p.n):
+            for i in range(p.m):
+                ci, Ji = p.scons(x, index=i, gradient=True)
+                self.assertAlmostEqual(ci, cdense[i], places=places, msg="scons ci is wrong 4 [i = %g]" % i)
+                self.assertTrue(array_compare(Jdense[i,:], Ji.toarray(), thresh=10 ** (-places)), msg="scons J is wrong 4 [i = %g]" % i)
+
+            # slagjac
+            g, J = p.slagjac(x)
+            gdense, Jdense = p.slagjac(x)
+            self.assertTrue(array_compare(gdense, g.toarray(), thresh=10 ** (-places)), msg="slagjac g wrong 1")
+            self.assertTrue(array_compare(Jdense, J.toarray(), thresh=10 ** (-places)), msg="slagjac J is wrong 1")
+            for v in vs:
+                g, J = p.slagjac(x, v=v)
+                gdense, Jdense = p.lagjac(x, v=v)
+                self.assertTrue(array_compare(gdense, g.toarray(), thresh=10 ** (-places)), msg="slagjac g wrong 2")
+                self.assertTrue(array_compare(Jdense, J.toarray(), thresh=10 ** (-places)), msg="slagjac J is wrong 2")
+            # sphess
+            for v in vs:
+                H = p.sphess(x, v=v)
+                Hdense = p.hess(x, v=v)
+                self.assertTrue(array_compare(Hdense, H.toarray(), thresh=10 ** (-places)), msg="sphess H wrong")
+            # isphess
+            H = p.isphess(x)
+            Hdense = p.ihess(x)
+            self.assertTrue(array_compare(Hdense, H.toarray(), thresh=10 ** (-places)), msg="isphess H wrong 0")
+            for i in range(p.m):
+                H = p.isphess(x, cons_index=i)
+                Hdense = p.ihess(x, cons_index=i)
+                self.assertTrue(array_compare(Hdense, H.toarray(), thresh=10 ** (-places)), msg="isphess H wrong [i = %g]" % i)
+            # gradsphess
+            for v in vs:
+                g, J, H = p.gradsphess(x, v=v)
+                gdense, Jdense, Hdense = p.gradhess(x, v=v)
+                self.assertTrue(array_compare(gdense, g.toarray(), thresh=10 ** (-places)), msg="gradsphess g wrong 1")
+                self.assertTrue(array_compare(Jdense, J.toarray(), thresh=10 ** (-places)), msg="gradsphess J wrong 1")
+                self.assertTrue(array_compare(Hdense, H.toarray(), thresh=10 ** (-places)), msg="gradsphess H wrong 1")
+                g, J, H = p.gradsphess(x, v=v, gradient_of_lagrangian=False)
+                gdense, Jdense, Hdense = p.gradhess(x, v=v, gradient_of_lagrangian=False)
+                self.assertTrue(array_compare(gdense, g.toarray(), thresh=10 ** (-places)), msg="gradsphess g wrong 2")
+                self.assertTrue(array_compare(Jdense, J.toarray(), thresh=10 ** (-places)), msg="gradsphess J wrong 2")
+                self.assertTrue(array_compare(Hdense, H.toarray(), thresh=10 ** (-places)), msg="gradsphess H wrong 2")
+
+
+class TestSparseUnconstrainedFixed(unittest.TestCase):
+    def runTest(self):
+        # pycutest.clear_cache('BOX2')
+        p = pycutest.import_problem('BOX2')
+        # Some test vectors
+        xs = [p.x0, np.ones((p.n,)), -np.ones((p.n)), 0.2*np.arange(p.n), np.sin(np.arange(p.n))-np.cos(np.arange(p.n))]
+
+        for x in xs:
+            places = 8  # accuracy
+            print("Trying x = [...]")
+            ftrue, gdense = p.obj(x, gradient=True)
+            Hdense = p.hess(x)
+            # scons
+            c = p.scons(x)
+            self.assertIsNone(c, msg="scons c is not None")
+            # slagjac
+            g, J = p.slagjac(x)
+            print(g.shape)
+            self.assertTrue(array_compare(gdense, g.toarray(), thresh=10**(-places)), msg="slagjac g wrong")
+            self.assertIsNone(J, msg="slagjac J is not None")
+            # sphess
+            H = p.sphess(x)
+            self.assertTrue(array_compare(Hdense, H.toarray(), thresh=10 ** (-places)), msg="sphess H wrong")
+            # isphess
+            H = p.isphess(x)
+            self.assertTrue(array_compare(Hdense, H.toarray(), thresh=10 ** (-places)), msg="isphess H wrong")
+            # gradsphess
+            g, H = p.gradsphess(x)
+            self.assertTrue(array_compare(gdense, g.toarray(), thresh=10 ** (-places)), msg="gradsphess g wrong")
+            self.assertTrue(array_compare(Hdense, H.toarray(), thresh=10 ** (-places)), msg="gradsphess H wrong")
+
+class TestSparseConstrainedFixed(unittest.TestCase):
+    def runTest(self):
+        # pycutest.clear_cache('ZIGZAG', sifParams={'T':10})
+        p = pycutest.import_problem('ZIGZAG', sifParams={'T':10})
+        # Some test vectors
+        xs = [p.x0, np.ones((p.n,)), -np.ones((p.n)), 0.2 * np.arange(p.n),
+              np.sin(np.arange(p.n)) - np.cos(np.arange(p.n))]
+
+        vs = [p.v0, np.ones((p.m,)), -np.ones((p.m)), 0.2 * np.arange(p.m),
+              np.sin(np.arange(p.m)) - np.cos(np.arange(p.m))]
+
+        for x in xs:
+            places = 8  # accuracy
+            print("Trying x = [...]")
+            cdense, Jdense = p.cons(x, gradient=True)
+            # scons
+            c = p.scons(x)
+            self.assertTrue(array_compare(cdense, c, thresh=10**(-places)), msg="scons c is wrong 1")
+            for i in range(p.m):
+                ci = p.scons(x, index=i)
+                self.assertAlmostEqual(ci, cdense[i], places=places, msg="scons ci is wrong 2 [i = %g]" % i)
+            c, J = p.scons(x, gradient=True)
+            self.assertTrue(array_compare(cdense, c, thresh=10 ** (-places)), msg="scons c is wrong 3")
+            self.assertTrue(array_compare(Jdense, J.toarray(), thresh=10 ** (-places)), msg="scons J is wrong 3")
+            for i in range(p.m):
                 ci, Ji = p.scons(x, index=i, gradient=True)
                 self.assertAlmostEqual(ci, cdense[i], places=places, msg="scons ci is wrong 4 [i = %g]" % i)
                 self.assertTrue(array_compare(Jdense[i,:], Ji.toarray(), thresh=10 ** (-places)), msg="scons J is wrong 4 [i = %g]" % i)


### PR DESCRIPTION
**Describe the change(s)**

The internal sparse Hessian function assumes wrong dimensions when creating the Hessian matrix. A difference occurs when n != n_full, i.e., if variables are dropped (e.g. instance `BOX2`). This results in a `ValueError('row index exceeds matrix dimesions')` being thrown by `scipy`.

**Have you updated the documentation?**

Yes

**Have you included relevant unit tests?**

No, I cannot get the test framework to work. But loading `BOX2` and executing `sphess` should be sufficient.
