### PR TITLE
Add access to constrained gradient only

### DIFF
--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -10,7 +10,7 @@ Problem Methods
 The methods available for each :code:`CUTEstProblem` instance are:
 
 * `obj(x[, gradient]) <methods/pycutest.CUTEstProblem.obj.html>`_: evaluate objective (and optionally its gradient)
-* `grad(x) <methods/pycutest.CUTEstProblem.grad.html>`_: evaluate objective gradient for unconstrained problems
+* `grad(x[, index]) <methods/pycutest.CUTEstProblem.grad.html>`_: evaluate objective gradient or specific constraint gradient
 * `objcons(x) <methods/pycutest.CUTEstProblem.objcons.html>`_: evaluate objective and constraints
 * `cons(x[, index, gradient]) <methods/pycutest.CUTEstProblem.cons.html>`_: evaluate constraint(s) and optionally their Jacobian/its gradient
 * `lagjac(x[, v]) <methods/pycutest.CUTEstProblem.lagjac.html>`_: evaluate gradient of objective/Lagrangian and Jacobian of constraints

--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -320,15 +320,13 @@ class CUTEstProblem(object):
             # gradient of i-th constraint
             g = problem.grad(x, index=i)
 
-        For constrained problems, this raises a RuntimeError.
-
         This calls CUTEst routine CUTEST_ugr or CUTEST_cigr.
 
         :param x: input vector
         :type x: numpy.ndarray with shape (n,)
         :param index: which constraint to evaluate. Must be in 0..self.m-1.
         :type index: int, optional
-        :return: gradient of objective at x or gradient of i-th constraint 
+        :return: gradient of objective or gradient of i-th constraint at x
         :rtype: numpy.ndarray(n,)
         """
         self.check_input_x(x)

--- a/pycutest/problem_class.py
+++ b/pycutest/problem_class.py
@@ -309,28 +309,33 @@ class CUTEstProblem(object):
             f = self._module.obj(self.free_to_all(x))
             return f
 
-    def grad(self, x):
+    def grad(self, x, index=None):
         """
-        Evaluate the gradient of the objective for unconstrained problems (for constrained problems please use lagjac() or obj()).
+        Evaluate the gradient of the objective function or gradient of the i-th constraint.
 
         .. code-block:: python
 
-            # gradient for unconstrained problems
+            # gradient of objective
             g = problem.grad(x)
+            # gradient of i-th constraint
+            g = problem.grad(x, index=i)
 
         For constrained problems, this raises a RuntimeError.
 
-        This calls CUTEst routine CUTEST_ugr.
+        This calls CUTEst routine CUTEST_ugr or CUTEST_cigr.
 
         :param x: input vector
         :type x: numpy.ndarray with shape (n,)
-        :return: gradient of objective at x
+        :param index: which constraint to evaluate. Must be in 0..self.m-1.
+        :type index: int, optional
+        :return: gradient of objective at x or gradient of i-th constraint 
         :rtype: numpy.ndarray(n,)
         """
-        if self.m > 0:
-            raise RuntimeError("For constrained problems please use lagjac() or obj()")
         self.check_input_x(x)
-        g = self._module.grad(self.free_to_all(x))
+        if index is None:
+            g = self._module.grad(self.free_to_all(x))
+        else:
+            g = self._module.grad(self.free_to_all(x), index)
         return self.all_to_free(g)
 
     def cons(self, x, index=None, gradient=False):

--- a/pycutest/tests/test_basic_functionality.py
+++ b/pycutest/tests/test_basic_functionality.py
@@ -224,6 +224,11 @@ class TestALLINITC_with_fixed(unittest.TestCase):
             f, g = p.obj(x, gradient=True)
             self.assertAlmostEqual(f, allinit_obj(x), places=places, msg="Wrong obj f value 2")
             self.assertTrue(array_compare(g, allinit_grad(x), thresh=10**(-places)), msg="Wrong obj g value 2")
+            # grad
+            g = p.grad(x)
+            self.assertTrue(array_compare(g, allinit_grad(x), thresh=10**(-places)), msg="Wrong grad g value")
+            g = p.grad(x,0)
+            self.assertTrue(array_compare(g, gradcons(x), thresh=10**(-places)), msg="Wrong grad g value 1")
             # cons
             c = p.cons(x)
             self.assertAlmostEqual(c, cons(x), places=places, msg="Wrong cons c value 1")
@@ -290,11 +295,11 @@ class TestALLINITC_with_fixed(unittest.TestCase):
         stats = p.report()
         num_xs = 4
         self.assertEqual(stats['f'], 3 * num_xs, msg="Wrong stat f")
-        self.assertEqual(stats['g'], (2 + 3*len(vs)) * num_xs, msg="Wrong stat g")
+        self.assertEqual(stats['g'], (3 + 3*len(vs)) * num_xs, msg="Wrong stat g")
         self.assertEqual(stats['H'], (1 + 3*len(vs) + 2*len(vs)*len(ps)) * num_xs, msg="Wrong stat H")
         self.assertEqual(stats['Hprod'], (2*len(vs)*len(ps)) * num_xs, msg="Wrong stat Hprod")
         self.assertEqual(stats['c'], (5 + len(vs) + len(ps)) * num_xs, msg="Wrong stat c")
-        self.assertEqual(stats['cg'], (3 + 5*len(vs) + 2*len(ps)) * num_xs, msg="Wrong stat cg")
+        self.assertEqual(stats['cg'], (4 + 5*len(vs) + 2*len(ps)) * num_xs, msg="Wrong stat cg")
         self.assertEqual(stats['cH'], (1 + 3*len(vs) + 2*len(ps)*len(vs)) * num_xs, msg="Wrong stat cH")
 
 
@@ -366,6 +371,11 @@ class TestALLINITC_with_free(unittest.TestCase):
             f, g = p.obj(x, gradient=True)
             self.assertAlmostEqual(f, obj(x), places=places, msg="Wrong obj f value 2")
             self.assertTrue(array_compare(g, grad(x), thresh=10**(-places)), msg="Wrong obj g value 2")
+            # grad
+            g = p.grad(x)
+            self.assertTrue(array_compare(g, grad(x), thresh=10**(-places)), msg="Wrong grad g value")
+            g = p.grad(x,0)
+            self.assertTrue(array_compare(g, gradcons(x), thresh=10**(-places)), msg="Wrong grad g value 1")
             # cons
             c = p.cons(x)
             self.assertAlmostEqual(c, cons(x), places=places, msg="Wrong cons c value 1")
@@ -432,11 +442,11 @@ class TestALLINITC_with_free(unittest.TestCase):
         stats = p.report()
         num_xs = 4
         self.assertEqual(stats['f'], 3 * num_xs, msg="Wrong stat f")
-        self.assertEqual(stats['g'], (2 + 3 * len(vs)) * num_xs, msg="Wrong stat g")
+        self.assertEqual(stats['g'], (3 + 3 * len(vs)) * num_xs, msg="Wrong stat g")
         self.assertEqual(stats['H'], (1 + 3 * len(vs) + 2 * len(vs) * len(ps)) * num_xs, msg="Wrong stat H")
         self.assertEqual(stats['Hprod'], (2 * len(vs) * len(ps)) * num_xs, msg="Wrong stat Hprod")
         self.assertEqual(stats['c'], (5 + len(vs) + len(ps)) * num_xs, msg="Wrong stat c")
-        self.assertEqual(stats['cg'], (3 + 5 * len(vs) + 2 * len(ps)) * num_xs, msg="Wrong stat cg")
+        self.assertEqual(stats['cg'], (4 + 5 * len(vs) + 2 * len(ps)) * num_xs, msg="Wrong stat cg")
         self.assertEqual(stats['cH'], (1 + 3 * len(vs) + 2 * len(ps) * len(vs)) * num_xs, msg="Wrong stat cH")
 
 


### PR DESCRIPTION
@lindonroberts this PR improves upon #69 by also adding access to the constrained gradient. This brings our interface in-line with the official CUTEst MATLAB interface:
https://github.com/ralna/CUTEst/tree/master/src/matlab

