### PR TITLE
Document the need to install Python headers on Ubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Requirements
 PyCUTEst requires the following software to be installed:
 
 * Python 3 (http://www.python.org/)
-* Python 3 Headers (:code:`apt install python3-dev` on Ubuntu)
+* Python 3 Headers (:code:`apt install python3-dev` on Ubuntu, already included on macOS)
 * CUTEst (see below)
 
 **Please Note:** Currently PyCUTEst only supports Mac and Linux. For Windows 10 (or later), PyCUTEst can be used through the `Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/>`_, following the Linux installation instructions.

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,7 @@ Requirements
 PyCUTEst requires the following software to be installed:
 
 * Python 3 (http://www.python.org/)
+* Python 3 Headers (:code:`apt install python3-dev` on Ubuntu)
 * CUTEst (see below)
 
 **Please Note:** Currently PyCUTEst only supports Mac and Linux. For Windows 10 (or later), PyCUTEst can be used through the `Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/>`_, following the Linux installation instructions.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,6 +6,7 @@ Requirements
 PyCUTEst requires the following software to be installed:
 
 * Python 3 (http://www.python.org/)
+* Python 3 Headers (:code:`apt install python3-dev` on Ubuntu)
 * CUTEst (see below)
 
 **Please Note:** Currently PyCUTEst only supports Mac and Linux. For Windows 10 (or later), PyCUTEst can be used through the `Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/>`_, following the Linux installation instructions.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,7 +6,7 @@ Requirements
 PyCUTEst requires the following software to be installed:
 
 * Python 3 (http://www.python.org/)
-* Python 3 Headers (:code:`apt install python3-dev` on Ubuntu)
+* Python 3 Headers (:code:`apt install python3-dev` on Ubuntu, already included on macOS)
 * CUTEst (see below)
 
 **Please Note:** Currently PyCUTEst only supports Mac and Linux. For Windows 10 (or later), PyCUTEst can be used through the `Windows Subsystem for Linux <https://docs.microsoft.com/en-us/windows/wsl/>`_, following the Linux installation instructions.


### PR DESCRIPTION
Resolves #79 

Ubuntu does not install the Python headers, including `Python.h`, by default. We require `Python.h` in order to compile the CUTEst problem C interfaces. 

This PR informs the user of this fact and shows them how to install the Python headers on Ubuntu in the README and install docs. As far as I am aware this is not required for macOS as their Python comes with the headers by default. No idea about other Linux distributions.