### PR TITLE
[CI] Switch to macOS 14 ARM64 runners

### DIFF
--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -39,7 +39,7 @@ jobs:
         export MASTSIF=/opt/homebrew/opt/mastsif/ &&
         source /opt/homebrew/opt/cutest/cutest.bashrc
         export PYCUTEST_CACHE="$GITHUB_WORKSPACE/pycutest_cache"
-        export MACOSX_DEPLOYMENT_TARGET=12.5
+        export MACOSX_DEPLOYMENT_TARGET=14.0
         export TERM=xterm
         python -m unittest pycutest.tests.test_sifdecode_extras
         python -m unittest pycutest.tests.test_basic_functionality

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -25,19 +25,19 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        sudo ln -s /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
-        sudo ln -s /usr/local/Cellar/gcc@11/*/lib/gcc/11/*.dylib /usr/local/lib/
+        sudo ln -s /opt/homebrew/bin/gfortran-12 /opt/homebrew/bin/gfortran
+        sudo ln -s /opt/homebrew/Cellar/gcc/12.*/lib/gcc/12/*.dylib /opt/homebrew/lib/
         brew tap optimizers/cutest &&
         brew install cutest --without-single
-        sudo ln -s $GITHUB_WORKSPACE/pycutest/tests/problems /usr/local/opt/mastsif &&
+        sudo ln -s $GITHUB_WORKSPACE/pycutest/tests/problems /opt/homebrew/opt/mastsif &&
         mkdir $GITHUB_WORKSPACE/pycutest_cache
         python -m pip install .
     - name: Tests
       run: |
-        source /usr/local/opt/archdefs/archdefs.bashrc &&
-        source /usr/local/opt/sifdecode/sifdecode.bashrc &&
-        export MASTSIF=/usr/local/opt/mastsif/ &&
-        source /usr/local/opt/cutest/cutest.bashrc
+        source /opt/homebrew/opt/archdefs/archdefs.bashrc &&
+        source /opt/homebrew/opt/sifdecode/sifdecode.bashrc &&
+        export MASTSIF=/opt/homebrew/opt/mastsif/ &&
+        source /opt/homebrew/opt/cutest/cutest.bashrc
         export PYCUTEST_CACHE="$GITHUB_WORKSPACE/pycutest_cache"
         export MACOSX_DEPLOYMENT_TARGET=12.5
         export TERM=xterm


### PR DESCRIPTION
GitHub Actions have moved the `macos-latest` runners over to macOS 14 ARM64.

This PR updates our macOS CI script to user these ARM-based macOS runners. Specifically it drops Python 3.8 and 3.9 from the Mac tests (as these are no longer supported) and switches over to the new homebrew prefix (`/opt/homebrew/`) used on the ARM-based Macs.
