### PR TITLE
Fix too small time array

### DIFF
--- a/pycutest/c_interface.py
+++ b/pycutest/c_interface.py
@@ -2080,7 +2080,7 @@ PyDoc_STRVAR(cutest_report_doc,
 );
 
 static PyObject *cutest_report(PyObject *self, PyObject *args) {
-    doublereal calls[7], time[2];
+    doublereal calls[7], time[4];
     PyObject *dict;
 
     if (!check_setup())


### PR DESCRIPTION
The CUTEst u/creport() time array increased in size from 2 to 4 a few years ago, correct the C interface to reflect this:
https://github.com/ralna/CUTEst/blob/master/src/tools/ureport.F90
https://github.com/ralna/CUTEst/blob/master/src/tools/creport.F90
The upstream PDF documentation needs to be updated to reflect this.