### PR TITLE
Fix memory leaks due to incorrect use of Py_BuildValue

### DIFF
--- a/pycutest/c_interface.py
+++ b/pycutest/c_interface.py
@@ -611,7 +611,7 @@ static PyObject *cutest_objcons(PyObject *self, PyObject *args) {
 
     CUTEST_cfn((integer *)&status, (integer *)&CUTEst_nvar, (integer *)&CUTEst_ncon, x, &f, c);
 
-    return Py_BuildValue("dO", f, Mc);
+    return Py_BuildValue("dN", f, Mc);
 }
 
 
@@ -665,7 +665,7 @@ static PyObject *cutest_obj(PyObject *self, PyObject *args) {
             return Py_BuildValue("d", f);
         } else {
             CUTEST_uofg((integer *)&status, (integer *)&CUTEst_nvar, x, &f, g, &somethingTrue);
-            return Py_BuildValue("dO", f, Mg);
+            return Py_BuildValue("dN", f, Mg);
         }
     } else {
         if (PyObject_Length(args)==1) {
@@ -673,7 +673,7 @@ static PyObject *cutest_obj(PyObject *self, PyObject *args) {
             return Py_BuildValue("d", f);
         } else {
             CUTEST_cofg((integer *)&status, (integer *)&CUTEst_nvar, x, &f, g, &somethingTrue);
-            return Py_BuildValue("dO", f, Mg);
+            return Py_BuildValue("dN", f, Mg);
         }
     }
 }
@@ -733,10 +733,10 @@ static PyObject *cutest_grad(PyObject *self, PyObject *args) {
 
     if (CUTEst_ncon == 0) {
         CUTEST_ugr((integer *)&status, (integer *)&CUTEst_nvar, x, g);
-        return Py_BuildValue("O", Mg);
+        return Py_BuildValue("N", Mg);
     } else {
         CUTEST_cigr((integer *)&status, (integer *)&CUTEst_nvar, (integer *)&icon, x, g);
-        return Py_BuildValue("O", Mg);
+        return Py_BuildValue("N", Mg);
     }
 }
 
@@ -836,7 +836,7 @@ static PyObject *cutest_cons(PyObject *self, PyObject *args) {
             CUTEST_ccfg((integer *)&status, (integer *)&CUTEst_nvar, (integer *)&CUTEst_ncon, x, c,
                     &somethingFalse, (integer *)&CUTEst_ncon, (integer *)&CUTEst_nvar, J,
                     &somethingTrue);
-            return Py_BuildValue("OO", Mc, MJ);
+            return Py_BuildValue("NN", Mc, MJ);
         }
     } else {
         if (!derivs) {
@@ -844,7 +844,7 @@ static PyObject *cutest_cons(PyObject *self, PyObject *args) {
             return (PyObject *)Mc;
         } else {
             CUTEST_ccifg((integer *)&status, (integer *)&CUTEst_nvar, (integer *)&icon, x, c, J, &somethingTrue);
-            return Py_BuildValue("OO", Mc, MJ);
+            return Py_BuildValue("NN", Mc, MJ);
         }
     }
 }
@@ -907,7 +907,7 @@ static PyObject *cutest_lag(PyObject *self, PyObject *args) {
         return Py_BuildValue("d", f);
     } else {
         CUTEST_clfg((integer *)&status, (integer *)&CUTEst_nvar, (integer *)&CUTEst_ncon, x, v, &f, g, &somethingTrue);
-        return Py_BuildValue("dO", f, Mg);
+        return Py_BuildValue("dN", f, Mg);
     }
 }
 
@@ -981,7 +981,7 @@ static PyObject *cutest_lagjac(PyObject *self, PyObject *args) {
             g, &somethingFalse, (integer *)&CUTEst_ncon, (integer *)&CUTEst_nvar, J);
     }
 
-    return Py_BuildValue("OO", Mg, MJ);
+    return Py_BuildValue("NN", Mg, MJ);
 }
 
 
@@ -1412,10 +1412,10 @@ static PyObject *cutest_gradhess(PyObject *self, PyObject *args) {
     if (CUTEst_ncon>0) {
         CUTEST_cgrdh((integer *)&status, (integer *)&CUTEst_nvar, (integer *)&CUTEst_ncon, x, v, (logical *)&grlagf,
                 g, &somethingFalse, (integer *)&CUTEst_ncon, (integer *)&CUTEst_nvar, J, (integer *)&CUTEst_nvar, H);
-        return Py_BuildValue("OOO", Mg, MJ, MH);
+        return Py_BuildValue("NNN", Mg, MJ, MH);
     } else {
         CUTEST_ugrdh((integer *)&status, (integer *)&CUTEst_nvar, x, g, (integer *)&CUTEst_nvar, H);
-        return Py_BuildValue("OO", Mg, MH);
+        return Py_BuildValue("NN", Mg, MH);
     }
 }
 
@@ -1480,7 +1480,7 @@ static PyObject *cutest_sobj(PyObject *self, PyObject *args) {
         free(si);
         free(sv);
 
-        return Py_BuildValue("dOO", f, Mgi, Mgv);
+        return Py_BuildValue("dNN", f, Mgi, Mgv);
     }
 }
 
@@ -1550,7 +1550,7 @@ static PyObject *cutest_sgrad(PyObject *self, PyObject *args) {
     free(si);
     free(sv);
 
-    return Py_BuildValue("OO", Mgi, Mgv);
+    return Py_BuildValue("NN", Mgi, Mgv);
 }
 
 
@@ -1637,7 +1637,7 @@ static PyObject *cutest_scons(PyObject *self, PyObject *args) {
             Jfi[i]--;
         }
 
-        return Py_BuildValue("OOOO", Mc, MJi, MJfi, MJv);
+        return Py_BuildValue("NNNN", Mc, MJi, MJfi, MJv);
     } else {
         x=(npy_double *)PyArray_DATA(arg1);
         si=(npy_int *)malloc(CUTEst_nvar*sizeof(npy_int));
@@ -1661,7 +1661,7 @@ static PyObject *cutest_scons(PyObject *self, PyObject *args) {
         free(si);
         free(sv);
 
-        return Py_BuildValue("OOO", Mc, Mgi, Mgv);
+        return Py_BuildValue("NNN", Mc, Mgi, Mgv);
     }
 }
 
@@ -1750,7 +1750,7 @@ static PyObject *cutest_slagjac(PyObject *self, PyObject *args) {
     free(sfi);
     free(sv);
 
-    return Py_BuildValue("OOOOO", Mgi, Mgv, MJi, MJfi, MJv);
+    return Py_BuildValue("NNNNN", Mgi, Mgv, MJi, MJfi, MJv);
 }
 
 
@@ -1836,7 +1836,7 @@ static PyObject *cutest_sphess(PyObject *self, PyObject *args) {
     free(sj);
     free(sv);
 
-    return Py_BuildValue("OOO", MHi, MHj, MHv);
+    return Py_BuildValue("NNN", MHi, MHj, MHv);
 }
 
 
@@ -1914,7 +1914,7 @@ static PyObject *cutest_isphess(PyObject *self, PyObject *args) {
     free(sj);
     free(sv);
 
-    return Py_BuildValue("OOO", MHi, MHj, MHv);
+    return Py_BuildValue("NNN", MHi, MHj, MHv);
 }
 
 
@@ -2048,9 +2048,9 @@ static PyObject *cutest_gradsphess(PyObject *self, PyObject *args) {
     free(sv);
 
     if (CUTEst_ncon>0) {
-        return Py_BuildValue("OOOOOOOO", Mgi, Mgv, MJi, MJfi, MJv, MHi, MHj, MHv);
+        return Py_BuildValue("NNNNNNNN", Mgi, Mgv, MJi, MJfi, MJv, MHi, MHj, MHv);
     } else {
-        return Py_BuildValue("OOOO", Mg, MHi, MHj, MHv);
+        return Py_BuildValue("NNNN", Mg, MHi, MHj, MHv);
     }
 }
 


### PR DESCRIPTION
Resolves #108 

**Problem description**
As detailed in #108, a bug was introduced when modernising the C interface that caused memory leaks.

Prior to the C interface modernisation, NumPy arrays created using the `PyArray_New` or `PyArray_SimpleNew` constructors were returned as tuples using the rather involved:
```C
return decRefTuple(PyTuple_Pack(2, Mc, MJ));
```
where the `decRefTuple` function decreased the reference count for each array in the tuple:
```C
/* Decrease reference count for newly created tuple members */
PyObject *decRefTuple(PyObject *tuple) {PyObject *decRefTuple(PyObject *tuple) {
    Py_ssize_t pos;
    for(pos=0;pos<PyTuple_Size(tuple);pos++) {
        Py_XDECREF(PyTuple_GetItem(tuple, pos));
    }
    return tuple;
}
``` 

Post C interface modernisation, since
> PyTuple_Pack(2, a, b) is equivalent to Py_BuildValue("(OO)", a, b)

this was replaced by the more modern `Py_BuildValue` syntax:
```C
return Py_BuildValue("OO", Mc, MJ);
```
but unfortunately the `"O"` format specifier is incorrect here as it increases the refcount of the arrays:
> O (object) [PyObject *]
Pass a Python object untouched but create a new [strong reference](https://docs.python.org/3/glossary.html#term-strong-reference) to it (i.e. its reference count is incremented by one).

the correct format specifier to use here is `"N"` which does not increase the refcount of the arrays:

> N (object) [PyObject *]
Same as O, except it doesn’t create a new [strong reference](https://docs.python.org/3/glossary.html#term-strong-reference).

**Proposed Resolution**
This PR replaces all occurrences of the `"O"` format specifier in all `Py_BuildValue` calls to the correct `"N"` format specifier since all the `"O"` specifiers refer to NumPy arrays created using `PyArray_New` or `PyArray_SimpleNew`.