### PR TITLE
Correctly parse multiple SIF parameters with new binary sifdecoder

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -44,5 +44,6 @@ jobs:
         python -m unittest pycutest.tests.test_basic_functionality
         python -m unittest pycutest.tests.test_sparse_functionality
         python -m unittest pycutest.tests.test_sifparam_chars
+        python -m unittest pycutest.tests.test_sifdecode_params
         python -m unittest pycutest.tests.test_multiple_instances
         python -m unittest pycutest.tests.test_restore_cwd

--- a/.github/workflows/test_linux_meson.yml
+++ b/.github/workflows/test_linux_meson.yml
@@ -51,5 +51,6 @@ jobs:
         python -m unittest pycutest.tests.test_basic_functionality
         python -m unittest pycutest.tests.test_sparse_functionality
         python -m unittest pycutest.tests.test_sifparam_chars
+        python -m unittest pycutest.tests.test_sifdecode_params
         python -m unittest pycutest.tests.test_multiple_instances
         python -m unittest pycutest.tests.test_restore_cwd

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -45,5 +45,6 @@ jobs:
         python -m unittest pycutest.tests.test_basic_functionality
         python -m unittest pycutest.tests.test_sparse_functionality
         python -m unittest pycutest.tests.test_sifparam_chars
+        python -m unittest pycutest.tests.test_sifdecode_params
         python -m unittest pycutest.tests.test_multiple_instances
         python -m unittest pycutest.tests.test_restore_cwd

--- a/.github/workflows/test_mac_brew_tap.yml
+++ b/.github/workflows/test_mac_brew_tap.yml
@@ -42,5 +42,6 @@ jobs:
         python -m unittest pycutest.tests.test_basic_functionality
         python -m unittest pycutest.tests.test_sparse_functionality
         python -m unittest pycutest.tests.test_sifparam_chars
+        python -m unittest pycutest.tests.test_sifdecode_params
         python -m unittest pycutest.tests.test_multiple_instances
         python -m unittest pycutest.tests.test_restore_cwd

--- a/.github/workflows/test_mac_meson.yml
+++ b/.github/workflows/test_mac_meson.yml
@@ -53,5 +53,6 @@ jobs:
         python -m unittest pycutest.tests.test_basic_functionality
         python -m unittest pycutest.tests.test_sparse_functionality
         python -m unittest pycutest.tests.test_sifparam_chars
+        python -m unittest pycutest.tests.test_sifdecode_params
         python -m unittest pycutest.tests.test_multiple_instances
         python -m unittest pycutest.tests.test_restore_cwd

--- a/pycutest/build_interface.py
+++ b/pycutest/build_interface.py
@@ -130,7 +130,8 @@ def decode_and_compile_problem(problemName, destination=None, sifParams=None, si
     * *sifParams* -- parameters passed to sifdecode using the ``-param`` command line option
       given in the form of a dictionary with parameter name as key. Values
       are converted to strings using :func:`str` and every parameter contributes
-      ``-param key=str(value)`` to the sifdecode's command line options.
+      ``key=str(value)`` to the comma separated list that is passed to sifdecode's
+      ``-param`` command line option (this works for both old and new sifdecode).
     * *sifOptions* -- additional options passed to sifdecode given in the form of a list of strings.
     * *quiet* -- supress output (default ``True``)
 
@@ -156,12 +157,15 @@ def decode_and_compile_problem(problemName, destination=None, sifParams=None, si
 
     # Handle params
     if sifParams is not None:
+        args += ['-param']
+        parlist = [] # comma separated params list
         for (key, value) in sifParams.items():
             if type(key) is not str:
                 if fromDir is not None:
                     os.chdir(fromDir) # Go back to original work directory
                 raise Exception("sifParams keys must be strings")
-            args+=['-param', key+"="+str(value)]
+            parlist += [key+"="+str(value)]
+        args += [",".join(parlist)]
 
     # Handle options
     if sifOptions is not None:
@@ -170,7 +174,7 @@ def decode_and_compile_problem(problemName, destination=None, sifParams=None, si
                 if fromDir is not None:
                     os.chdir(fromDir) # Go back to original work directory
                 raise Exception("sifOptions must consist of strings")
-            args+=[str(opt)]
+            args += [str(opt)]
 
     # Call sifdecode
     spawnOK=True

--- a/pycutest/tests/problems/FLETCBV3.SIF
+++ b/pycutest/tests/problems/FLETCBV3.SIF
@@ -1,0 +1,179 @@
+***************************
+* SET UP THE INITIAL DATA *
+***************************
+
+NAME          FLETCBV3 
+
+*   Problem :
+*   *********
+
+*   Another Boundary Value problem.
+
+*   Source:  The first problem given by
+*   R. Fletcher,
+*   "An optimal positive definite update for sparse Hessian matrices"
+*   Numerical Analysis report NA/145, University of Dundee, 1992.
+
+*   Scaled version.
+
+*   SIF input: Nick Gould, Oct 1992.
+
+*   classification OUR2-AN-V-0
+
+*   The number of variables is N.
+
+*IE N                   10             $-PARAMETER     original value
+*IE N                   100            $-PARAMETER
+*IE N                   1000           $-PARAMETER
+ IE N                   5000           $-PARAMETER
+*IE N                   10000          $-PARAMETER
+
+*  KAPPA a parameter.
+
+ RE KAPPA               1.0            $-PARAMETER
+*RE KAPPA               0.0            $-PARAMETER
+
+ RE OBJSCALE            1.0D+8
+
+*   Define useful parameters
+
+ IE 0                   0
+ IE 1                   1
+ IE 2                   2
+ RE 1.0                 1.0
+ IA N-1       N         -1
+
+ R/ P         1.0                      OBJSCALE
+
+ IA N+1       N         1
+ RI RN+1      N+1
+ R/ H         1.0                      RN+1  
+ R* H2        H                        H
+ R* 1/H2      RN+1                     RN+1
+ R* KAPPA/H2  1/H2                     KAPPA
+ RM -KAPPA/H2 KAPPA/H2  -1.0
+ RM 2/H2      1/H2      2.0
+ RA 1+2/H2    2/H2      1.0
+ RM -1-2/H2   1+2/H2    -1.0
+ R* P*-1-2/H2 1+2/H2                   P
+
+
+VARIABLES
+
+ DO I         1                        N
+ X  X(I)
+ ND
+
+GROUPS
+
+*ZN G(0)      'SCALE'                  OBJSCALE
+ XN G(0)      X(1)      1.0
+
+ DO I         1                        N-1
+ IA I+1       I         1
+*ZN G(I)      'SCALE'                  OBJSCALE
+ XN G(I)      X(I)      1.0            X(I+1)    -1.0
+ ND
+
+*ZN G(N)      'SCALE'                  OBJSCALE
+ XN G(N)      X(N)       1.0
+
+ DO I         1                        N
+*ZN L(I)      'SCALE'                  OBJSCALE
+ ZN L(I)      X(I)                     P*-1-2/H2
+ ND
+
+ DO I         1                        N
+*ZN C(I)      'SCALE'                  OBJSCALE
+ ZN C(I)
+ ND
+
+BOUNDS
+
+ FR FLETCBV3  'DEFAULT'
+
+START POINT
+
+*V  FLETCBV3  'DEFAULT' 0.0
+
+ DO I         1                        N
+ RI RI        I  
+ R* IH        RI                       H
+ Z  FLETCBV3  X(I)                     IH
+ ND
+
+ELEMENT TYPE
+
+ EV COS       V
+ EP COS       P
+
+ELEMENT USES
+
+ T  'DEFAULT' COS
+
+ DO I         1                        N    
+ ZV C(I)      V                        X(I)
+ ZP C(I)      P                        P
+ ND
+
+GROUP TYPE
+
+ GV HALFL2    GVAR
+ GP HALFL2    P
+
+GROUP USES
+
+ DO I         0                        N
+ XT G(I)      HALFL2
+ ZP G(I)      P                        P
+ ND
+
+ DO I         1                        N
+ ZE C(I)      C(I)                     -KAPPA/H2
+ ND
+
+OBJECT BOUND
+
+*   Solution
+
+*LO SOLTN                ??
+
+ENDATA
+
+***********************
+* SET UP THE FUNCTION *
+* AND RANGE ROUTINES  *
+***********************
+
+ELEMENTS      FLETCBV3 
+
+TEMPORARIES
+
+ M  COS
+ M  SIN
+
+INDIVIDUALS
+
+ T  COS   
+ F                      P * COS( V )
+ G  V                   - P * SIN( V )
+ H  V         V         - P * COS( V )
+
+ENDATA
+
+*********************
+* SET UP THE GROUPS *
+* ROUTINE           *
+*********************
+
+GROUPS        FLETCBV3 
+
+INDIVIDUALS
+
+ T  HALFL2
+
+ F                      5.0D-1 * P * GVAR * GVAR
+ G                      P * GVAR
+ H                      P
+
+ENDATA

--- a/pycutest/tests/test_sifdecode_params.py
+++ b/pycutest/tests/test_sifdecode_params.py
@@ -1,0 +1,15 @@
+import pycutest
+import unittest
+
+# All problems used here: FLETCBV3
+
+
+class TestFLETCBV3(unittest.TestCase):
+    def runTest(self):
+        pycutest.clear_cache('FLETCBV3', sifParams={'N': 10, 'KAPPA': 0.0})
+        p = pycutest.import_problem('FLETCBV3', sifParams={'N': 10, 'KAPPA': 0.0})
+        self.assertEqual(p.name, 'FLETCBV3', msg="Wrong name")
+        self.assertEqual(p.sifParams['N'], 10, msg="Wrong N sifParam")
+        self.assertEqual(p.sifParams['KAPPA'], 0.0, msg="Wrong KAPPA sifParam")
+        self.assertEqual(p.n_free, 10, msg="Wrong number of free variables")
+        # This problem has multiple parameters in sifParams and sifdecode needs to handle this


### PR DESCRIPTION
Resolves #110 

As reported in #110, we are currently incorrectly parsing multiple SIF parameters when using the new binary SIFDecoder.

The original SIFDecoder bash script supports two ways to pass multiple SIF parameters to it, from its docs:

> -param : cast probname[.SIF] against explicit parameter settings. Several parameter settings may be given as a comma-separated list following -param or using several -param flags. Use -show to view possible settings.

and PyCUTEst, like PyCUTEr before it, has always used the latter option of a -param flag for each SIF parameter.

Unfortunately, this is no longer supported in the new SIFDecoder binary, which only accepts the former: a comma separated list of parameters and their values after the -param flag, from the binary SIFDecoder docs:

>  -param : cast problem[.SIF] against explicit parameter settings. Several parameter settings may be given as a comma-separated list following -param. Use sifdecoder -show problem to view possible settings. If a setting is not allowed in the SIF file, no action is taken unless -force is present.

This PR alters the code in `build_interface.py` so that we pass a comma separated list of parameter settings as supported by both the original SIFDecoder bash script and the new SIFDecoder binary (that is the default for meson and brew installs). 

A new unit test is also added to ensure that we correctly parse multiple SIF parameters, since we never actually tested this before! 

This change should be completely transparent to PyCUTEst users.